### PR TITLE
Call order repository for refund revocation

### DIFF
--- a/Models/OrderModel.cs
+++ b/Models/OrderModel.cs
@@ -247,7 +247,7 @@ namespace GMS.TifoXRCoreWebAPI.Models
         public string ChargeId { get; set; } = default!;
         public string RefundId { get; set; } = default!;
         public string ProviderRefundId { get; set; } = default!;
-        public int StatusId { get; set; } // e.g., 3 = succeeded
+        public int StatusId { get; set; } // RefundStatus enum (1=pending, 2=succeeded, 3=failed, 4=canceled)
         public long RefundedAmountMinor { get; set; }
         public int CurrencyId { get; set; }
     }

--- a/Repositories/Interfaces/IOrderRepository.Entitlements.cs
+++ b/Repositories/Interfaces/IOrderRepository.Entitlements.cs
@@ -10,6 +10,7 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
     public partial interface IOrderRepository
     {
         Task GrantEntitlementsAsync(string orderId);
+        Task RevokeEntitlementsAsync(string orderId, string reason);
     }
 }
 

--- a/Repositories/Interfaces/IOrderRepository.Status.cs
+++ b/Repositories/Interfaces/IOrderRepository.Status.cs
@@ -1,0 +1,14 @@
+﻿// <copyright file="IOrderRepository.Status.cs" company="Global Mobile Software LLC">
+// Copyright © 2025 All Rights Reserved
+// </copyright>
+// <author>Saad Sohail</author>
+// <date>09/16/2025</date>
+// <summary></summary>
+
+namespace GMS.TifoXRCoreWebAPI.Repositories
+{
+    public partial interface IOrderRepository
+    {
+        Task RevokeOrderAsync(string orderId, string? reason);
+    }
+}

--- a/Repositories/OrderRepository.Entitlements.cs
+++ b/Repositories/OrderRepository.Entitlements.cs
@@ -27,6 +27,21 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
 
             await cmd.ExecuteNonQueryAsync();
         }
+
+        public async Task RevokeEntitlementsAsync(string orderId, string reason)
+        {
+            const int RevokedStatus = 3; // your entitlement status for "revoked"       //FIX ME: Get from look up tables
+
+            await using var conn = await _db.OpenConnectionAsync();
+            await using var cmd = _db.CreateCommand(conn, Entitlement_RevokeByOrder);
+
+            cmd.Parameters.Add(_db.CreateParameter("@OrderId", orderId));
+            cmd.Parameters.Add(_db.CreateParameter("@RevokedStatus", RevokedStatus));
+            cmd.Parameters.Add(_db.CreateParameter("@Reason", (object?)reason ?? DBNull.Value));
+            cmd.Parameters.Add(_db.CreateParameter("@ModBy", "system"));
+
+            await cmd.ExecuteNonQueryAsync();
+        }
     }
 }
 

--- a/Repositories/OrderRepository.Reconcile.cs
+++ b/Repositories/OrderRepository.Reconcile.cs
@@ -7,6 +7,7 @@
 
 using GMS.TifoXRCoreWebAPI.Models;
 using static GMS.TifoXRCoreWebAPI.Repositories.SQL.PaymentIntentSql;
+using static GMS.TifoXRCoreWebAPI.Repositories.SQL.OrderSql;
 
 namespace GMS.TifoXRCoreWebAPI.Repositories
 {
@@ -41,6 +42,7 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
 
             return list;
         }
+
     }
 }
 

--- a/Repositories/OrderRepository.Status.cs
+++ b/Repositories/OrderRepository.Status.cs
@@ -1,0 +1,29 @@
+﻿// <copyright file="OrderRepository.Status.cs" company="Global Mobile Software LLC">
+// Copyright © 2025 All Rights Reserved
+// </copyright>
+// <author>Saad Sohail</author>
+// <date>09/16/2025</date>
+// <summary></summary>
+
+using static GMS.TifoXRCoreWebAPI.Repositories.SQL.OrderSql;
+
+namespace GMS.TifoXRCoreWebAPI.Repositories
+{
+    public sealed partial class OrderRepository : IOrderRepository
+    {
+        public async Task RevokeOrderAsync(string orderId, string? reason)
+        {
+            const int RevokedStatusId = 4; // your order status for "revoked"       //FIX ME: Get from look up tables
+
+            await using var conn = await _db.OpenConnectionAsync();
+            await using var cmd = _db.CreateCommand(conn, Order_UpdateStatus);
+
+            cmd.Parameters.Add(_db.CreateParameter("@OrderId", orderId));
+            cmd.Parameters.Add(_db.CreateParameter("@StatusId", RevokedStatusId));
+            cmd.Parameters.Add(_db.CreateParameter("@ChangeReason", (object?)reason ?? DBNull.Value));
+            cmd.Parameters.Add(_db.CreateParameter("@ModBy", "system"));
+
+            await cmd.ExecuteNonQueryAsync();
+        }
+    }
+}

--- a/Repositories/Sql/OrderSql.cs
+++ b/Repositories/Sql/OrderSql.cs
@@ -129,6 +129,13 @@ namespace GMS.TifoXRCoreWebAPI.Repositories.SQL
             UPDATE `order` SET status_id=@PaidStatusId, modified_by=@ModBy
             WHERE id=@OrderId AND status_id<>@PaidStatusId;";
 
+        internal const string Order_UpdateStatus = @"
+            UPDATE `order`
+            SET status_id=@StatusId,
+                change_reason=@ChangeReason,
+                modified_by=@ModBy
+            WHERE id=@OrderId;";
+
         internal const string Order_GetHeader = @"
             SELECT space_id, currency_id, total_net_amount, gateway_preferred_id
             FROM `order` WHERE id=@OrderId LIMIT 1;";

--- a/Repositories/Sql/PaymentIntentSql.cs
+++ b/Repositories/Sql/PaymentIntentSql.cs
@@ -116,7 +116,7 @@ namespace GMS.TifoXRCoreWebAPI.Repositories.SQL
             JOIN payment_intent pi ON pi.id = pc.payment_intent_id
             JOIN `order` o        ON o.id  = pi.order_id
             LEFT JOIN payment_refund pr ON pr.payment_charge_id = pc.id
-                                       AND pr.status_id = 3      -- succeeded only
+                                       AND pr.status_id = 2      -- succeeded only
             WHERE pc.id = @ChargeId
             GROUP BY o.id, o.space_id, o.currency_id, pi.payment_gateway_id, pc.provider_charge_id, pc.amount_captured;
         ";
@@ -133,6 +133,14 @@ namespace GMS.TifoXRCoreWebAPI.Repositories.SQL
                 WHERE ol.order_id = @OrderId
                   AND o.status_id = @OrderStatusPaid
                   AND e.id IS NULL;";
+
+        internal const string Entitlement_RevokeByOrder = @"
+            UPDATE entitlement e
+            JOIN order_line ol ON ol.id = e.order_line_id
+            SET e.status = @RevokedStatus,
+                e.revoked_reason = @Reason,
+                e.modified_by = @ModBy
+            WHERE ol.order_id = @OrderId;";
     }
 }
 

--- a/Services/Interfaces/IOrderService.cs
+++ b/Services/Interfaces/IOrderService.cs
@@ -15,5 +15,6 @@ namespace GMS.TifoXRCoreWebAPI.Services
         Task<OrderDto?> GetOrderAsync(int spaceId, string orderId);
         Task<InvoiceListResponse?> GetInvoicesAsync(int spaceId, string orderId);
         Task<List<EntitlementDto>?> GetEntitlementsByOrderAsync(int spaceId, string orderId);
+        Task RevokeOrderAsync(string orderId, string? reason = null);
     }
 }

--- a/Services/OrderService.cs
+++ b/Services/OrderService.cs
@@ -26,5 +26,16 @@ namespace GMS.TifoXRCoreWebAPI.Services
 
         public Task<List<EntitlementDto>?> GetEntitlementsByOrderAsync(int spaceId, string orderId)
             => _repo.GetEntitlementsByOrderAsync(spaceId, orderId);
+
+        public async Task RevokeOrderAsync(string orderId, string? reason = null)
+        {
+            if (string.IsNullOrWhiteSpace(orderId))
+                throw new ArgumentException("OrderId is required.", nameof(orderId));
+
+            var revokeReason = reason ?? "Order revoked";
+
+            await _repo.RevokeEntitlementsAsync(orderId, revokeReason);
+            await _repo.RevokeOrderAsync(orderId, revokeReason);
+        }
     }
 }

--- a/Services/PaymentHandlers/RefundHandler.cs
+++ b/Services/PaymentHandlers/RefundHandler.cs
@@ -14,7 +14,10 @@ using GMS.TifoXRCoreWebAPI.Utilities.Domain.Enums;
 
 namespace GMS.TifoXRCoreWebAPI.Services.PaymentHandlers
 {
-    public sealed class RefundHandler(IPaymentGatewayResolver resolver, IOrderRepository orders, IRefundPolicyResolver refundPolicies)
+    public sealed class RefundHandler(
+        IPaymentGatewayResolver resolver,
+        IOrderRepository orders,
+        IRefundPolicyResolver refundPolicies)
     {
         private readonly IPaymentGatewayResolver _resolver = resolver;
         private readonly IOrderRepository _orders = orders;
@@ -58,14 +61,21 @@ namespace GMS.TifoXRCoreWebAPI.Services.PaymentHandlers
                 Reason: normalizedReason
             ));
 
+            var refundStatus = RefundStatus.Succeeded;
+
             var refundId = await _orders.InsertRefundAsync(
                 chargeId: chargeId,
-                statusId: (int)PaymentIntentStatus.Succeeded,
+                statusId: (int)refundStatus,
                 amountMinor: MoneyConverter.ToMinor(prov.RefundedAmount),
                 currencyId: c.CurrencyId,
                 providerRefundId: prov.ProviderRefundId,
                 reason: req.Reason
             );
+
+            var revokeReason = req.Reason ?? "Refund succeeded";
+
+            await _orders.RevokeEntitlementsAsync(orderId, revokeReason);
+            await _orders.RevokeOrderAsync(orderId, revokeReason);
 
             return new RefundResponse
             {
@@ -73,7 +83,7 @@ namespace GMS.TifoXRCoreWebAPI.Services.PaymentHandlers
                 ChargeId = chargeId,
                 RefundId = refundId,
                 ProviderRefundId = prov.ProviderRefundId,
-                StatusId = (int)PaymentIntentStatus.Succeeded,
+                StatusId = (int)refundStatus,
                 RefundedAmountMinor = MoneyConverter.ToMinor(prov.RefundedAmount),
                 CurrencyId = c.CurrencyId
             };

--- a/Utilities/Domain/Enums/RefundStatus.cs
+++ b/Utilities/Domain/Enums/RefundStatus.cs
@@ -1,0 +1,10 @@
+namespace GMS.TifoXRCoreWebAPI.Utilities.Domain.Enums
+{
+    public enum RefundStatus
+    {
+        Pending = 1,
+        Succeeded = 2,
+        Failed = 3,
+        Canceled = 4
+    }
+}


### PR DESCRIPTION
## Summary
- update the refund handler to revoke entitlements and order status directly through the order repository
- remove the order service dependency from the refund handler constructor

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d41d022d648329964a938735cab47a