### PR TITLE
Add rules engine evaluation endpoint

### DIFF
--- a/Controllers/RulesEvaluationController.cs
+++ b/Controllers/RulesEvaluationController.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using GMS.TifoXRCoreWebAPI.Models;
+using GMS.TifoXRCoreWebAPI.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+
+namespace GMS.TifoXRCoreWebAPI.Controllers
+{
+    [ApiController]
+    [Route("api/rules/runtime")]
+    public sealed class RulesEvaluationController : ControllerBase
+    {
+        private readonly IRulesEvaluationService _service;
+        private readonly ILogger<RulesEvaluationController> _logger;
+
+        public RulesEvaluationController(IRulesEvaluationService service, ILogger<RulesEvaluationController> logger)
+        {
+            _service = service;
+            _logger = logger;
+        }
+
+        [HttpPost("evaluate")]
+        [ProducesResponseType(typeof(RulesEngineEvaluationResponse), StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        public async Task<ActionResult<RulesEngineEvaluationResponse>> EvaluateAsync(
+            [FromBody] RulesEngineEvaluationRequest request,
+            CancellationToken cancellationToken)
+        {
+            if (request is null)
+            {
+                return BadRequest("Request body is required.");
+            }
+
+            if (request.SpaceId <= 0)
+            {
+                return BadRequest("spaceId must be a positive integer.");
+            }
+
+            if (string.IsNullOrWhiteSpace(request.EventType))
+            {
+                return BadRequest("eventType is required.");
+            }
+
+            try
+            {
+                var response = await _service.EvaluateAsync(request, cancellationToken);
+                return Ok(response);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to evaluate rules for event {EventType} in space {SpaceId}.", request.EventType, request.SpaceId);
+                return StatusCode(StatusCodes.Status500InternalServerError, "An error occurred while evaluating the rules.");
+            }
+        }
+    }
+}

--- a/Models/RulesModels.cs
+++ b/Models/RulesModels.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Text.Json;
 
 namespace GMS.TifoXRCoreWebAPI.Models
 {
@@ -280,6 +281,47 @@ namespace GMS.TifoXRCoreWebAPI.Models
         public DateTime OccurredAt { get; init; }
         public string? PropertiesJson { get; init; }
         public DateTime IngestedAt { get; init; }
+    }
+
+    // =========================
+    // Runtime: Rules evaluation
+    // =========================
+
+    public sealed class RulesEngineEvaluationRequest
+    {
+        public int SpaceId { get; init; }
+        public string EventType { get; init; } = default!;
+        public DateTime OccurredAt { get; init; }
+        public string? ActorUserId { get; init; }
+        public string? TargetUserId { get; init; }
+        public string? ContentOwnerUserId { get; init; }
+        public string? ContentRef { get; init; }
+        public Dictionary<string, JsonElement>? Properties { get; init; }
+    }
+
+    public sealed class RulesEngineEvaluationResponse
+    {
+        public bool AnyRuleMatched { get; init; }
+        public IReadOnlyList<RuleEvaluationOutcome> Outcomes { get; init; } = Array.Empty<RuleEvaluationOutcome>();
+        public IReadOnlyList<RewardDecision> RewardDecisions { get; init; } = Array.Empty<RewardDecision>();
+        public IReadOnlyList<string> Messages { get; init; } = Array.Empty<string>();
+    }
+
+    public sealed class RuleEvaluationOutcome
+    {
+        public string RuleName { get; init; } = default!;
+        public bool IsSuccess { get; init; }
+        public string? SuccessEvent { get; init; }
+        public string? ErrorMessage { get; init; }
+        public string? RewardCode { get; init; }
+    }
+
+    public sealed class RewardDecision
+    {
+        public string RuleName { get; init; } = default!;
+        public bool Granted { get; init; }
+        public string? RewardCode { get; init; }
+        public string? Notes { get; init; }
     }
 
     // =========================

--- a/Program.cs
+++ b/Program.cs
@@ -154,6 +154,7 @@ static void ConfigureServices(IServiceCollection services,  IConfiguration confi
 
     services.AddScoped<ILookupService, LookupService>();
     services.AddScoped<IRulesAuthoringService, RulesAuthoringService>();
+    services.AddScoped<IRulesEvaluationService, RulesEvaluationService>();
     services.AddScoped<IRewardService, RewardService>();
 
     #endregion

--- a/Services/Interfaces/IRulesEvaluationService.cs
+++ b/Services/Interfaces/IRulesEvaluationService.cs
@@ -1,0 +1,15 @@
+﻿// <copyright file="IRulesEvaluationService.cs" company="Global Mobile Software LLC">
+// Copyright © 2025 All Rights Reserved
+// </copyright>
+
+using System.Threading;
+using System.Threading.Tasks;
+using GMS.TifoXRCoreWebAPI.Models;
+
+namespace GMS.TifoXRCoreWebAPI.Services
+{
+    public interface IRulesEvaluationService
+    {
+        Task<RulesEngineEvaluationResponse> EvaluateAsync(RulesEngineEvaluationRequest request, CancellationToken cancellationToken = default);
+    }
+}

--- a/Services/RulesEvaluationService.cs
+++ b/Services/RulesEvaluationService.cs
@@ -1,0 +1,208 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Dynamic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using RulesEngine.Models;
+
+using RulesEngineCore = RulesEngine.RulesEngine;
+
+using GMS.TifoXRCoreWebAPI.Models;
+
+namespace GMS.TifoXRCoreWebAPI.Services
+{
+    public sealed class RulesEvaluationService : IRulesEvaluationService
+    {
+        private readonly ILogger<RulesEvaluationService> _logger;
+        private readonly RulesEngineCore _rulesEngine;
+        private readonly Dictionary<string, string> _workflowLookup;
+
+        public RulesEvaluationService(IConfiguration configuration, ILogger<RulesEvaluationService> logger)
+        {
+            _logger = logger;
+
+            var configured = configuration.GetSection("RulesEngine:Workflows").Get<Workflow[]>();
+            Workflow[] workflows;
+
+            if (configured is { Length: > 0 })
+            {
+                workflows = configured;
+            }
+            else
+            {
+                workflows = BuildDefaultWorkflows();
+                _logger.LogWarning("RulesEngine configuration not found. Using built-in demonstration workflow definitions.");
+            }
+
+            _rulesEngine = new RulesEngineCore(workflows);
+            _workflowLookup = workflows
+                .Where(w => !string.IsNullOrWhiteSpace(w.WorkflowName))
+                .ToDictionary(w => w.WorkflowName!, w => w.WorkflowName!, StringComparer.OrdinalIgnoreCase);
+        }
+
+        public async Task<RulesEngineEvaluationResponse> EvaluateAsync(RulesEngineEvaluationRequest request, CancellationToken cancellationToken = default)
+        {
+            if (request is null) throw new ArgumentNullException(nameof(request));
+
+            if (!_workflowLookup.TryGetValue(request.EventType, out var workflowName))
+            {
+                _logger.LogInformation("No workflow configured for event type {EventType}.", request.EventType);
+                return new RulesEngineEvaluationResponse
+                {
+                    AnyRuleMatched = false,
+                    Messages = new[] { $"No workflow configured for event type '{request.EventType}'." }
+                };
+            }
+
+            var parameters = new[]
+            {
+                new RuleParameter("input1", BuildPropertyBag(request.Properties)),
+                new RuleParameter("event", request)
+            };
+
+            List<RuleResultTree> results;
+
+            try
+            {
+                results = await _rulesEngine.ExecuteAllRulesAsync(workflowName, parameters);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to execute rules workflow {WorkflowName}.", workflowName);
+                throw;
+            }
+
+            var outcomes = results.Select(ToOutcome).ToList();
+            var rewardDecisions = outcomes
+                .Where(o => !string.IsNullOrWhiteSpace(o.RewardCode))
+                .Select(o => new RewardDecision
+                {
+                    RuleName = o.RuleName,
+                    Granted = o.IsSuccess,
+                    RewardCode = o.RewardCode,
+                    Notes = o.IsSuccess ? "Rule matched." : o.ErrorMessage
+                })
+                .ToList();
+
+            return new RulesEngineEvaluationResponse
+            {
+                AnyRuleMatched = outcomes.Any(o => o.IsSuccess),
+                Outcomes = outcomes,
+                RewardDecisions = rewardDecisions
+            };
+        }
+
+        private static RuleEvaluationOutcome ToOutcome(RuleResultTree result)
+        {
+            var successEvent = result.Rule.SuccessEvent;
+            var rewardCode = TryParseRewardCode(successEvent);
+
+            return new RuleEvaluationOutcome
+            {
+                RuleName = result.Rule.RuleName,
+                IsSuccess = result.IsSuccess,
+                SuccessEvent = successEvent,
+                ErrorMessage = result.Rule.ErrorMessage,
+                RewardCode = rewardCode
+            };
+        }
+
+        private static string? TryParseRewardCode(string? successEvent)
+        {
+            if (string.IsNullOrWhiteSpace(successEvent))
+            {
+                return null;
+            }
+
+            const string Prefix = "reward:";
+
+            return successEvent.StartsWith(Prefix, StringComparison.OrdinalIgnoreCase)
+                ? successEvent[Prefix.Length..]
+                : null;
+        }
+
+        private static Workflow[] BuildDefaultWorkflows()
+        {
+            return new[]
+            {
+                new Workflow
+                {
+                    WorkflowName = "game.session.ended",
+                    Rules = new List<Rule>
+                    {
+                        new Rule
+                        {
+                            RuleName = "Grant reward for high score in hard difficulty",
+                            Enabled = true,
+                            SuccessEvent = "reward:penalties-hard-champion",
+                            ErrorMessage = "Score or difficulty requirements not met.",
+                            RuleExpressionType = RuleExpressionType.LambdaExpression,
+                            Expression = "event.SpaceId == 42 && input1.score >= 7 && input1.difficulty != null && input1.difficulty.ToString().ToLower() == \"hard\""
+                        }
+                    }
+                }
+            };
+        }
+
+        private static ExpandoObject BuildPropertyBag(Dictionary<string, JsonElement>? properties)
+        {
+            var expando = new ExpandoObject();
+            var dict = (IDictionary<string, object?>)expando;
+
+            if (properties is null)
+            {
+                return expando;
+            }
+
+            foreach (var (key, value) in properties)
+            {
+                dict[key] = ConvertJsonElement(value);
+            }
+
+            return expando;
+        }
+
+        private static object? ConvertJsonElement(JsonElement element)
+        {
+            return element.ValueKind switch
+            {
+                JsonValueKind.Object => BuildNestedObject(element),
+                JsonValueKind.Array => BuildArray(element),
+                JsonValueKind.String => element.GetString(),
+                JsonValueKind.Number => element.TryGetInt64(out var l) ? l : element.GetDouble(),
+                JsonValueKind.True => true,
+                JsonValueKind.False => false,
+                JsonValueKind.Null => null,
+                _ => element.ToString()
+            };
+        }
+
+        private static object BuildArray(JsonElement element)
+        {
+            var list = new List<object?>();
+            foreach (var item in element.EnumerateArray())
+            {
+                list.Add(ConvertJsonElement(item));
+            }
+
+            return list;
+        }
+
+        private static ExpandoObject BuildNestedObject(JsonElement element)
+        {
+            var expando = new ExpandoObject();
+            var dict = (IDictionary<string, object?>)expando;
+
+            foreach (var property in element.EnumerateObject())
+            {
+                dict[property.Name] = ConvertJsonElement(property.Value);
+            }
+
+            return expando;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce runtime DTOs and evaluation service powered by the Microsoft RulesEngine library
- expose a new API endpoint to trigger reward evaluation and wire the service into dependency injection
- translate incoming event payloads into rule parameters and surface reward decisions in the response

## Testing
- dotnet build *(fails: `dotnet` CLI is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68daed1582cc8329aa16b903ebd61ce4