### PR TITLE
Load rules engine workflows from database

### DIFF
--- a/Controllers/RulesEvaluationController.cs
+++ b/Controllers/RulesEvaluationController.cs
@@ -44,6 +44,8 @@ namespace GMS.TifoXRCoreWebAPI.Controllers
                 return BadRequest("eventType is required.");
             }
 
+            request.SpaceId = spaceId;
+
             try
             {
                 var response = await _service.EvaluateAsync(request, cancellationToken);

--- a/Models/RulesModels.cs
+++ b/Models/RulesModels.cs
@@ -60,9 +60,6 @@ namespace GMS.TifoXRCoreWebAPI.Models
         public int SpaceId { get; init; }
         public string Name { get; init; } = default!;
         public int StateTypeId { get; init; }
-        public DateTime CreationTime { get; init; }
-        public DateTime ModifiedTime { get; init; }
-        public string ModifiedBy { get; init; } = default!;
     }
 
     public sealed class RuleCreateDto
@@ -90,9 +87,6 @@ namespace GMS.TifoXRCoreWebAPI.Models
         public int Priority { get; init; }
         public int RuleCooldownSeconds { get; init; }
         public int StateTypeId { get; init; }
-        public DateTime CreationTime { get; init; }
-        public DateTime ModifiedTime { get; init; }
-        public string ModifiedBy { get; init; } = default!;
     }
 
     // =========================
@@ -289,6 +283,7 @@ namespace GMS.TifoXRCoreWebAPI.Models
 
     public sealed class RulesEngineEvaluationRequest
     {
+        public int SpaceId { get; set; }
         public string EventType { get; init; } = default!;
         public DateTime OccurredAt { get; init; }
         public string? ActorUserId { get; init; }
@@ -296,6 +291,34 @@ namespace GMS.TifoXRCoreWebAPI.Models
         public string? ContentOwnerUserId { get; init; }
         public string? ContentRef { get; init; }
         public Dictionary<string, JsonElement>? Properties { get; init; }
+    }
+
+    public sealed class RuntimeWorkflowDefinition
+    {
+        public int WorkflowId { get; init; }
+        public string WorkflowName { get; init; } = default!;
+        public string EventType { get; init; } = default!;
+        public int? EventTypeId { get; init; }
+        public IReadOnlyList<RuntimeRuleDefinition> Rules { get; init; } = Array.Empty<RuntimeRuleDefinition>();
+        public IReadOnlyDictionary<string, RuntimeParameterDefinition> Parameters { get; init; }
+            = new Dictionary<string, RuntimeParameterDefinition>(StringComparer.OrdinalIgnoreCase);
+    }
+
+    public sealed class RuntimeRuleDefinition
+    {
+        public int RuleId { get; init; }
+        public string RuleName { get; init; } = default!;
+        public string Expression { get; init; } = default!;
+        public string? SuccessEvent { get; init; }
+    }
+
+    public sealed class RuntimeParameterDefinition
+    {
+        public string Key { get; init; } = default!;
+        public string Source { get; init; } = default!;
+        public string Path { get; init; } = default!;
+        public bool IsRequired { get; init; }
+        public string? DefaultValueJson { get; init; }
     }
 
     public sealed class RulesEngineEvaluationResponse

--- a/Repositories/Interfaces/IRulesRepository.cs
+++ b/Repositories/Interfaces/IRulesRepository.cs
@@ -26,5 +26,7 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
         Task<IReadOnlyList<int>> InsertConditionsAsync(IEnumerable<ConditionCreateDto> dtos);
         Task<int> CreateRuleActionAsync(RuleActionCreateDto dto);
         Task BindRewardToActionAsync(int actionId, int rewardId);
+
+        Task<IReadOnlyList<RuntimeWorkflowDefinition>> GetRuntimeWorkflowsAsync(int spaceId);
     }
 }

--- a/Repositories/RulesRepository.cs
+++ b/Repositories/RulesRepository.cs
@@ -5,6 +5,9 @@
 // <date>09/30/2025</date>
 // <summary>Rules engine authoring data access.</summary>
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using GMS.TifoXRCoreWebAPI.Models;
 using GMS.TifoXRCoreWebAPI.Repositories.Sql;
 using GMS.TifoXRCoreWebAPI.Utilities.Infrastructure;
@@ -223,6 +226,170 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
             cmd.Parameters.Add(_db.CreateParameter("@RewardId", rewardId));
 
             await cmd.ExecuteNonQueryAsync();
+        }
+
+        public async Task<IReadOnlyList<RuntimeWorkflowDefinition>> GetRuntimeWorkflowsAsync(int spaceId)
+        {
+            await using var conn = await _db.OpenConnectionAsync();
+
+            var builders = new Dictionary<int, RuntimeWorkflowBuilder>();
+            var eventTypeIds = new HashSet<int>();
+
+            await using (var cmd = _db.CreateCommand(conn, RulesSql.GetRuntimeWorkflows))
+            {
+                cmd.Parameters.Add(_db.CreateParameter("@SpaceId", spaceId));
+
+                await using var rdr = await cmd.ExecuteReaderAsync();
+                if (!rdr.HasRows)
+                {
+                    return Array.Empty<RuntimeWorkflowDefinition>();
+                }
+
+                var workflowIdIdx = rdr.GetOrdinal("WorkflowId");
+                var workflowNameIdx = rdr.GetOrdinal("WorkflowName");
+                var ruleIdIdx = rdr.GetOrdinal("RuleId");
+                var ruleNameIdx = rdr.GetOrdinal("RuleName");
+                var expressionIdx = rdr.GetOrdinal("Expression");
+                var successEventIdx = rdr.GetOrdinal("SuccessEvent");
+                var eventTypeIdx = rdr.GetOrdinal("EventType");
+                var eventTypeIdIdx = rdr.GetOrdinal("EventTypeId");
+
+                while (await rdr.ReadAsync())
+                {
+                    var workflowId = rdr.GetInt32(workflowIdIdx);
+                    var workflowName = rdr.GetString(workflowNameIdx);
+                    var eventType = rdr.IsDBNull(eventTypeIdx)
+                        ? workflowName
+                        : rdr.GetString(eventTypeIdx);
+                    var eventTypeId = rdr.IsDBNull(eventTypeIdIdx)
+                        ? (int?)null
+                        : rdr.GetInt32(eventTypeIdIdx);
+
+                    if (!builders.TryGetValue(workflowId, out var builder))
+                    {
+                        builder = new RuntimeWorkflowBuilder(workflowId, workflowName, eventType, eventTypeId);
+                        builders.Add(workflowId, builder);
+                    }
+
+                    if (eventTypeId.HasValue)
+                    {
+                        eventTypeIds.Add(eventTypeId.Value);
+                    }
+
+                    if (rdr.IsDBNull(expressionIdx))
+                    {
+                        continue;
+                    }
+
+                    var expression = rdr.GetString(expressionIdx);
+                    if (string.IsNullOrWhiteSpace(expression))
+                    {
+                        continue;
+                    }
+
+                    var rule = new RuntimeRuleDefinition
+                    {
+                        RuleId = rdr.GetInt32(ruleIdIdx),
+                        RuleName = rdr.GetString(ruleNameIdx),
+                        Expression = expression,
+                        SuccessEvent = rdr.IsDBNull(successEventIdx) ? null : rdr.GetString(successEventIdx)
+                    };
+
+                    builder.AddRule(rule);
+                }
+            }
+
+            if (builders.Count == 0)
+            {
+                return Array.Empty<RuntimeWorkflowDefinition>();
+            }
+
+            var parameterCache = new Dictionary<int, IReadOnlyDictionary<string, RuntimeParameterDefinition>>();
+
+            foreach (var eventTypeId in eventTypeIds)
+            {
+                await using var paramCmd = _db.CreateCommand(conn, RulesSql.GetRuntimeEventParameters);
+                paramCmd.Parameters.Add(_db.CreateParameter("@EventTypeId", eventTypeId));
+
+                await using var paramRdr = await paramCmd.ExecuteReaderAsync();
+                if (!paramRdr.HasRows)
+                {
+                    continue;
+                }
+
+                var keyIdx = paramRdr.GetOrdinal("ParameterKey");
+                var sourceIdx = paramRdr.GetOrdinal("Source");
+                var pathIdx = paramRdr.GetOrdinal("Path");
+                var requiredIdx = paramRdr.GetOrdinal("IsRequired");
+                var defaultIdx = paramRdr.GetOrdinal("DefaultValueJson");
+
+                var parameters = new Dictionary<string, RuntimeParameterDefinition>(StringComparer.OrdinalIgnoreCase);
+
+                while (await paramRdr.ReadAsync())
+                {
+                    var key = paramRdr.GetString(keyIdx);
+
+                    parameters[key] = new RuntimeParameterDefinition
+                    {
+                        Key = key,
+                        Source = paramRdr.GetString(sourceIdx),
+                        Path = paramRdr.GetString(pathIdx),
+                        IsRequired = paramRdr.GetInt32(requiredIdx) != 0,
+                        DefaultValueJson = paramRdr.IsDBNull(defaultIdx) ? null : paramRdr.GetString(defaultIdx)
+                    };
+                }
+
+                parameterCache[eventTypeId] = parameters;
+            }
+
+            foreach (var builder in builders.Values)
+            {
+                if (builder.EventTypeId.HasValue &&
+                    parameterCache.TryGetValue(builder.EventTypeId.Value, out var parameters))
+                {
+                    builder.SetParameters(parameters);
+                }
+            }
+
+            return builders.Values
+                .Select(b => b.ToDefinition())
+                .ToList();
+        }
+
+        private sealed class RuntimeWorkflowBuilder
+        {
+            private readonly List<RuntimeRuleDefinition> _rules = new();
+            private IReadOnlyDictionary<string, RuntimeParameterDefinition> _parameters =
+                new Dictionary<string, RuntimeParameterDefinition>(StringComparer.OrdinalIgnoreCase);
+
+            public RuntimeWorkflowBuilder(int workflowId, string workflowName, string eventType, int? eventTypeId)
+            {
+                WorkflowId = workflowId;
+                WorkflowName = workflowName;
+                EventType = eventType;
+                EventTypeId = eventTypeId;
+            }
+
+            public int WorkflowId { get; }
+            public string WorkflowName { get; }
+            public string EventType { get; }
+            public int? EventTypeId { get; }
+
+            public void AddRule(RuntimeRuleDefinition rule) => _rules.Add(rule);
+
+            public void SetParameters(IReadOnlyDictionary<string, RuntimeParameterDefinition> parameters)
+                => _parameters = parameters;
+
+            public RuntimeWorkflowDefinition ToDefinition()
+                => new()
+                {
+                    WorkflowId = WorkflowId,
+                    WorkflowName = WorkflowName,
+                    EventType = EventType,
+                    EventTypeId = EventTypeId,
+                    Rules = _rules,
+                    Parameters = _parameters
+                };
         }
     }
 }

--- a/Repositories/Sql/RulesSql.cs
+++ b/Repositories/Sql/RulesSql.cs
@@ -76,5 +76,32 @@ namespace GMS.TifoXRCoreWebAPI.Repositories.Sql
             INSERT INTO rule_action_reward (id, reward_id, creation_time, modified_by)
             VALUES (@ActionId, @RewardId, NOW(6), 'system')
             ON DUPLICATE KEY UPDATE reward_id = VALUES(reward_id), modified_by = 'system';";
+
+        public const string GetRuntimeWorkflows = @"
+            SELECT w.id AS WorkflowId,
+                   w.name AS WorkflowName,
+                   r.id AS RuleId,
+                   r.rule_name AS RuleName,
+                   r.expression AS Expression,
+                   r.success_event AS SuccessEvent,
+                   r.target_type AS EventType,
+                   et.id AS EventTypeId
+            FROM workflow w
+            JOIN rules r ON r.workflow_id = w.id
+            LEFT JOIN re_event_type et ON et.name = r.target_type
+            WHERE w.space_id = @SpaceId
+            ORDER BY w.id, r.priority, r.id;";
+
+        public const string GetRuntimeEventParameters = @"
+            SELECT etp.re_event_type_id AS EventTypeId,
+                   cp.`key` AS ParameterKey,
+                   cp.source AS Source,
+                   cp.path AS Path,
+                   (etp.is_required + 0) AS IsRequired,
+                   etp.default_value_json AS DefaultValueJson
+            FROM re_event_type_parameter etp
+            JOIN re_context_parameter cp ON cp.id = etp.parameter_id
+            WHERE etp.re_event_type_id = @EventTypeId
+            ORDER BY etp.id;";
     }
 }

--- a/Services/RulesEvaluationService.cs
+++ b/Services/RulesEvaluationService.cs
@@ -1,207 +1,361 @@
-﻿// <copyright file="RulesEvaluationService.cs" company="Global Mobile Software LLC">
-// Copyright © 2025 All Rights Reserved</copyright>
-// <author>Saad Sohail</author>
-// <date>9/30/2025</date>
-// <summary></summary>
-
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Dynamic;
+using System.Linq;
 using System.Text.Json;
-//
+using System.Threading;
 using RulesEngine.Models;
 using RulesEngineCore = RulesEngine.RulesEngine;
-//
 using GMS.TifoXRCoreWebAPI.Models;
+using GMS.TifoXRCoreWebAPI.Repositories;
 
-namespace GMS.TifoXRCoreWebAPI.Services
+namespace GMS.TifoXRCoreWebAPI.Services;
+
+public sealed class RulesEvaluationService : IRulesEvaluationService
 {
-    public sealed class RulesEvaluationService : IRulesEvaluationService
+    private readonly ILogger<RulesEvaluationService> _logger;
+    private readonly IRulesRepository _rulesRepository;
+    private readonly ConcurrentDictionary<int, WorkflowCache> _workflowCaches = new();
+
+    public RulesEvaluationService(IRulesRepository rulesRepository, ILogger<RulesEvaluationService> logger)
     {
-        private readonly ILogger<RulesEvaluationService> _logger;
-        private readonly RulesEngineCore _rulesEngine;
-        private readonly Dictionary<string, string> _workflowLookup;
+        _rulesRepository = rulesRepository ?? throw new ArgumentNullException(nameof(rulesRepository));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
 
-        public RulesEvaluationService(IConfiguration configuration, ILogger<RulesEvaluationService> logger)
+    public async Task<RulesEngineEvaluationResponse> EvaluateAsync(
+        RulesEngineEvaluationRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        if (request is null) throw new ArgumentNullException(nameof(request));
+
+        if (request.SpaceId <= 0)
         {
-            _logger = logger;
-
-            var configured = configuration.GetSection("RulesEngine:Workflows").Get<Workflow[]>();
-            Workflow[] workflows;
-
-            if (configured is { Length: > 0 })
-            {
-                workflows = configured;
-            }
-            else
-            {
-                workflows = BuildDefaultWorkflows();
-                _logger.LogWarning("RulesEngine configuration not found. Using built-in demonstration workflow definitions.");
-            }
-
-            _rulesEngine = new RulesEngineCore(workflows);
-            _workflowLookup = workflows
-                .Where(w => !string.IsNullOrWhiteSpace(w.WorkflowName))
-                .ToDictionary(w => w.WorkflowName!, w => w.WorkflowName!, StringComparer.OrdinalIgnoreCase);
+            throw new ArgumentException("SpaceId must be provided on the evaluation request.", nameof(request));
         }
 
-        public async Task<RulesEngineEvaluationResponse> EvaluateAsync(RulesEngineEvaluationRequest request, CancellationToken cancellationToken = default)
+        var cache = await GetWorkflowCacheAsync(request.SpaceId, cancellationToken);
+
+        if (cache.Engine is null || cache.WorkflowLookup.Count == 0)
         {
-            if (request is null) throw new ArgumentNullException(nameof(request));
-
-            if (!_workflowLookup.TryGetValue(request.EventType, out var workflowName))
+            _logger.LogInformation("No workflows configured in database for space {SpaceId}.", request.SpaceId);
+            return new RulesEngineEvaluationResponse
             {
-                _logger.LogInformation("No workflow configured for event type {EventType}.", request.EventType);
-                return new RulesEngineEvaluationResponse
-                {
-                    AnyRuleMatched = false,
-                    Messages = new[] { $"No workflow configured for event type '{request.EventType}'." }
-                };
-            }
-
-            var parameters = new[]
-            {
-                new RuleParameter("input1", BuildPropertyBag(request.Properties)),
-                new RuleParameter("event", request)
+                AnyRuleMatched = false,
+                Messages = new[] { $"No workflows configured for space '{request.SpaceId}'." }
             };
+        }
 
-            List<RuleResultTree> results;
-
-            try
-            {
-                results = await _rulesEngine.ExecuteAllRulesAsync(workflowName, parameters);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to execute rules workflow {WorkflowName}.", workflowName);
-                throw;
-            }
-
-            var outcomes = results.Select(ToOutcome).ToList();
-            var rewardDecisions = outcomes
-                .Where(o => !string.IsNullOrWhiteSpace(o.RewardCode))
-                .Select(o => new RewardDecision
-                {
-                    RuleName = o.RuleName,
-                    Granted = o.IsSuccess,
-                    RewardCode = o.RewardCode,
-                    Notes = o.IsSuccess ? "Rule matched." : o.ErrorMessage
-                })
-                .ToList();
+        if (!cache.WorkflowLookup.TryGetValue(request.EventType, out var workflowName))
+        {
+            _logger.LogInformation(
+                "No workflow configured for event type {EventType} in space {SpaceId}.",
+                request.EventType,
+                request.SpaceId);
 
             return new RulesEngineEvaluationResponse
             {
-                AnyRuleMatched = outcomes.Any(o => o.IsSuccess),
-                Outcomes = outcomes,
-                RewardDecisions = rewardDecisions
+                AnyRuleMatched = false,
+                Messages = new[] { $"No workflow configured for event type '{request.EventType}'." }
             };
         }
 
-        private static RuleEvaluationOutcome ToOutcome(RuleResultTree result)
-        {
-            var successEvent = result.Rule.SuccessEvent;
-            var rewardCode = TryParseRewardCode(successEvent);
+        cache.ParameterMap.TryGetValue(workflowName, out var parameterDefinitions);
 
-            return new RuleEvaluationOutcome
-            {
-                RuleName = result.Rule.RuleName,
-                IsSuccess = result.IsSuccess,
-                SuccessEvent = successEvent,
-                ErrorMessage = result.Rule.ErrorMessage,
-                RewardCode = rewardCode
-            };
+        var parameters = new[]
+        {
+            new RuleParameter("input1", BuildPropertyBag(request, parameterDefinitions)),
+            new RuleParameter("event", request)
+        };
+
+        List<RuleResultTree> results;
+
+        try
+        {
+            results = await cache.Engine.ExecuteAllRulesAsync(workflowName, parameters);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to execute rules workflow {WorkflowName}.", workflowName);
+            throw;
         }
 
-        private static string? TryParseRewardCode(string? successEvent)
-        {
-            if (string.IsNullOrWhiteSpace(successEvent))
+        var outcomes = results.Select(ToOutcome).ToList();
+        var rewardDecisions = outcomes
+            .Where(o => !string.IsNullOrWhiteSpace(o.RewardCode))
+            .Select(o => new RewardDecision
             {
-                return null;
-            }
+                RuleName = o.RuleName,
+                Granted = o.IsSuccess,
+                RewardCode = o.RewardCode,
+                Notes = o.IsSuccess ? "Rule matched." : o.ErrorMessage
+            })
+            .ToList();
 
-            const string Prefix = "reward:";
+        return new RulesEngineEvaluationResponse
+        {
+            AnyRuleMatched = outcomes.Any(o => o.IsSuccess),
+            Outcomes = outcomes,
+            RewardDecisions = rewardDecisions
+        };
+    }
 
-            return successEvent.StartsWith(Prefix, StringComparison.OrdinalIgnoreCase)
-                ? successEvent[Prefix.Length..]
-                : null;
+    private async Task<WorkflowCache> GetWorkflowCacheAsync(int spaceId, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (_workflowCaches.TryGetValue(spaceId, out var cached))
+        {
+            return cached;
         }
 
-        private static Workflow[] BuildDefaultWorkflows()
+        IReadOnlyList<RuntimeWorkflowDefinition> definitions;
+
+        try
         {
-            return new[]
+            definitions = await _rulesRepository.GetRuntimeWorkflowsAsync(spaceId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load workflow definitions for space {SpaceId}.", spaceId);
+            throw;
+        }
+
+        if (definitions.Count == 0)
+        {
+            _workflowCaches[spaceId] = WorkflowCache.Empty;
+            return WorkflowCache.Empty;
+        }
+
+        var validDefinitions = definitions
+            .Where(d => d.Rules.Count > 0)
+            .ToList();
+
+        if (validDefinitions.Count == 0)
+        {
+            _workflowCaches[spaceId] = WorkflowCache.Empty;
+            return WorkflowCache.Empty;
+        }
+
+        var workflows = validDefinitions
+            .Select(d => new Workflow
             {
-                new Workflow
+                WorkflowName = d.EventType,
+                Rules = d.Rules.Select(r => new Rule
                 {
-                    WorkflowName = "game.session.ended",
-                    Rules = new List<Rule>
-                    {
-                        new Rule
-                        {
-                            RuleName = "Grant reward for high score in hard difficulty",
-                            Enabled = true,
-                            SuccessEvent = "reward:penalties-hard-champion",
-                            ErrorMessage = "Score or difficulty requirements not met.",
-                            RuleExpressionType = RuleExpressionType.LambdaExpression,
-                            Expression = "event.SpaceId == 42 && input1.score >= 7 && input1.difficulty != null && input1.difficulty.ToString().ToLower() == \"hard\""
-                        }
-                    }
-                }
-            };
+                    RuleName = r.RuleName,
+                    Expression = r.Expression,
+                    SuccessEvent = r.SuccessEvent,
+                    RuleExpressionType = RuleExpressionType.LambdaExpression,
+                    Enabled = true
+                }).ToList()
+            })
+            .ToArray();
+
+        if (workflows.Length == 0)
+        {
+            _workflowCaches[spaceId] = WorkflowCache.Empty;
+            return WorkflowCache.Empty;
         }
 
-        private static ExpandoObject BuildPropertyBag(Dictionary<string, JsonElement>? properties)
+        var engine = new RulesEngineCore(workflows);
+
+        var lookup = validDefinitions
+            .Where(d => !string.IsNullOrWhiteSpace(d.EventType))
+            .ToDictionary(d => d.EventType, d => d.EventType, StringComparer.OrdinalIgnoreCase);
+
+        var parameterMap = validDefinitions
+            .Where(d => !string.IsNullOrWhiteSpace(d.EventType))
+            .ToDictionary(
+                d => d.EventType,
+                d => d.Parameters,
+                StringComparer.OrdinalIgnoreCase);
+
+        var cache = new WorkflowCache(engine, lookup, parameterMap);
+        _workflowCaches[spaceId] = cache;
+        return cache;
+    }
+
+    private static ExpandoObject BuildPropertyBag(
+        RulesEngineEvaluationRequest request,
+        IReadOnlyDictionary<string, RuntimeParameterDefinition>? parameters)
+    {
+        var expando = new ExpandoObject();
+        var dict = (IDictionary<string, object?>)expando;
+
+        if (request.Properties is not null)
         {
-            var expando = new ExpandoObject();
-            var dict = (IDictionary<string, object?>)expando;
-
-            if (properties is null)
-            {
-                return expando;
-            }
-
-            foreach (var (key, value) in properties)
+            foreach (var (key, value) in request.Properties)
             {
                 dict[key] = ConvertJsonElement(value);
             }
-
-            return expando;
         }
 
-        private static object? ConvertJsonElement(JsonElement element)
+        if (parameters is not null)
         {
-            return element.ValueKind switch
+            foreach (var parameter in parameters.Values)
             {
-                JsonValueKind.Object => BuildNestedObject(element),
-                JsonValueKind.Array => BuildArray(element),
-                JsonValueKind.String => element.GetString(),
-                JsonValueKind.Number => element.TryGetInt64(out var l) ? l : element.GetDouble(),
-                JsonValueKind.True => true,
-                JsonValueKind.False => false,
-                JsonValueKind.Null => null,
-                _ => element.ToString()
-            };
-        }
-
-        private static object BuildArray(JsonElement element)
-        {
-            var list = new List<object?>();
-            foreach (var item in element.EnumerateArray())
-            {
-                list.Add(ConvertJsonElement(item));
+                dict[parameter.Key] = ResolveParameterValue(parameter, request);
             }
-
-            return list;
         }
 
-        private static ExpandoObject BuildNestedObject(JsonElement element)
+        return expando;
+    }
+
+    private static object? ResolveParameterValue(
+        RuntimeParameterDefinition definition,
+        RulesEngineEvaluationRequest request)
+    {
+        object? value = null;
+
+        if (string.Equals(definition.Source, "event", StringComparison.OrdinalIgnoreCase))
         {
-            var expando = new ExpandoObject();
-            var dict = (IDictionary<string, object?>)expando;
-
-            foreach (var property in element.EnumerateObject())
-            {
-                dict[property.Name] = ConvertJsonElement(property.Value);
-            }
-
-            return expando;
+            value = ResolveEventValue(definition.Path, request.Properties);
         }
+
+        if (value is null && !string.IsNullOrWhiteSpace(definition.DefaultValueJson))
+        {
+            value = ParseDefaultValue(definition.DefaultValueJson);
+        }
+
+        return value;
+    }
+
+    private static object? ResolveEventValue(string path, Dictionary<string, JsonElement>? properties)
+    {
+        if (properties is null || string.IsNullOrWhiteSpace(path))
+        {
+            return null;
+        }
+
+        var segments = ParsePathSegments(path);
+        if (segments.Count == 0)
+        {
+            return null;
+        }
+
+        if (!properties.TryGetValue(segments[0], out var current))
+        {
+            return null;
+        }
+
+        for (var i = 1; i < segments.Count; i++)
+        {
+            if (current.ValueKind != JsonValueKind.Object || !current.TryGetProperty(segments[i], out current))
+            {
+                return null;
+            }
+        }
+
+        return ConvertJsonElement(current);
+    }
+
+    private static IReadOnlyList<string> ParsePathSegments(string path)
+    {
+        var trimmed = path.Trim();
+
+        if (trimmed.StartsWith("$.", StringComparison.Ordinal))
+        {
+            trimmed = trimmed[2..];
+        }
+        else if (trimmed.StartsWith("$", StringComparison.Ordinal))
+        {
+            trimmed = trimmed[1..];
+        }
+
+        return trimmed.Split('.', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+    }
+
+    private static object? ParseDefaultValue(string json)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            return ConvertJsonElement(doc.RootElement);
+        }
+        catch (JsonException)
+        {
+            return json;
+        }
+    }
+
+    private static RuleEvaluationOutcome ToOutcome(RuleResultTree result)
+    {
+        var successEvent = result.Rule.SuccessEvent;
+        var rewardCode = TryParseRewardCode(successEvent);
+
+        return new RuleEvaluationOutcome
+        {
+            RuleName = result.Rule.RuleName,
+            IsSuccess = result.IsSuccess,
+            SuccessEvent = successEvent,
+            ErrorMessage = result.Rule.ErrorMessage,
+            RewardCode = rewardCode
+        };
+    }
+
+    private static string? TryParseRewardCode(string? successEvent)
+    {
+        if (string.IsNullOrWhiteSpace(successEvent))
+        {
+            return null;
+        }
+
+        const string Prefix = "reward:";
+
+        return successEvent.StartsWith(Prefix, StringComparison.OrdinalIgnoreCase)
+            ? successEvent[Prefix.Length..]
+            : null;
+    }
+
+    private static object? ConvertJsonElement(JsonElement element)
+    {
+        return element.ValueKind switch
+        {
+            JsonValueKind.Object => BuildNestedObject(element),
+            JsonValueKind.Array => BuildArray(element),
+            JsonValueKind.String => element.GetString(),
+            JsonValueKind.Number => element.TryGetInt64(out var l) ? l : element.GetDouble(),
+            JsonValueKind.True => true,
+            JsonValueKind.False => false,
+            JsonValueKind.Null => null,
+            _ => element.ToString()
+        };
+    }
+
+    private static object BuildArray(JsonElement element)
+    {
+        var list = new List<object?>();
+        foreach (var item in element.EnumerateArray())
+        {
+            list.Add(ConvertJsonElement(item));
+        }
+
+        return list;
+    }
+
+    private static ExpandoObject BuildNestedObject(JsonElement element)
+    {
+        var expando = new ExpandoObject();
+        var dict = (IDictionary<string, object?>)expando;
+
+        foreach (var property in element.EnumerateObject())
+        {
+            dict[property.Name] = ConvertJsonElement(property.Value);
+        }
+
+        return expando;
+    }
+
+    private sealed record WorkflowCache(
+        RulesEngineCore? Engine,
+        IReadOnlyDictionary<string, string> WorkflowLookup,
+        IReadOnlyDictionary<string, IReadOnlyDictionary<string, RuntimeParameterDefinition>> ParameterMap)
+    {
+        public static readonly WorkflowCache Empty = new(
+            null,
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase),
+            new Dictionary<string, IReadOnlyDictionary<string, RuntimeParameterDefinition>>(StringComparer.OrdinalIgnoreCase));
     }
 }


### PR DESCRIPTION
## Summary
- fetch rules engine workflows, rules, and parameter definitions from the database instead of configuration
- add runtime DTOs plus repository queries to hydrate evaluation inputs from stored context metadata
- propagate the space id into evaluation requests and remove unused creation/modification fields from rule view models

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68daff5a4f7483298b2aa0456b236d92