### PR TITLE
Handle missing parameter values without overwriting request data

### DIFF
--- a/Services/RulesEvaluationService.cs
+++ b/Services/RulesEvaluationService.cs
@@ -196,7 +196,16 @@ public sealed class RulesEvaluationService : IRulesEvaluationService
         {
             foreach (var parameter in parameters.Values)
             {
-                dict[parameter.Key] = ResolveParameterValue(parameter, request);
+                var resolved = ResolveParameterValue(parameter, request);
+
+                if (resolved is not null)
+                {
+                    dict[parameter.Key] = resolved;
+                }
+                else if (!dict.ContainsKey(parameter.Key))
+                {
+                    dict[parameter.Key] = resolved;
+                }
             }
         }
 
@@ -235,20 +244,70 @@ public sealed class RulesEvaluationService : IRulesEvaluationService
             return null;
         }
 
-        if (!properties.TryGetValue(segments[0], out var current))
+        if (!TryGetValueCaseInsensitive(properties, segments[0], out var current))
         {
             return null;
         }
 
         for (var i = 1; i < segments.Count; i++)
         {
-            if (current.ValueKind != JsonValueKind.Object || !current.TryGetProperty(segments[i], out current))
+            if (current.ValueKind != JsonValueKind.Object ||
+                !TryGetPropertyCaseInsensitive(current, segments[i], out current))
             {
                 return null;
             }
         }
 
         return ConvertJsonElement(current);
+    }
+
+    private static bool TryGetValueCaseInsensitive(
+        IReadOnlyDictionary<string, JsonElement> dictionary,
+        string key,
+        out JsonElement value)
+    {
+        if (dictionary.TryGetValue(key, out value))
+        {
+            return true;
+        }
+
+        foreach (var pair in dictionary)
+        {
+            if (string.Equals(pair.Key, key, StringComparison.OrdinalIgnoreCase))
+            {
+                value = pair.Value;
+                return true;
+            }
+        }
+
+        value = default;
+        return false;
+    }
+
+    private static bool TryGetPropertyCaseInsensitive(JsonElement element, string propertyName, out JsonElement value)
+    {
+        if (element.ValueKind != JsonValueKind.Object)
+        {
+            value = default;
+            return false;
+        }
+
+        if (element.TryGetProperty(propertyName, out value))
+        {
+            return true;
+        }
+
+        foreach (var property in element.EnumerateObject())
+        {
+            if (string.Equals(property.Name, propertyName, StringComparison.OrdinalIgnoreCase))
+            {
+                value = property.Value;
+                return true;
+            }
+        }
+
+        value = default;
+        return false;
     }
 
     private static IReadOnlyList<string> ParsePathSegments(string path)

--- a/TifoXRCoreWebAPI.Tests/Services/RulesEvaluationServiceTests.cs
+++ b/TifoXRCoreWebAPI.Tests/Services/RulesEvaluationServiceTests.cs
@@ -1,0 +1,76 @@
+using System.Text.Json;
+using FluentAssertions;
+using GMS.TifoXRCoreWebAPI.Models;
+using GMS.TifoXRCoreWebAPI.Repositories;
+using GMS.TifoXRCoreWebAPI.Services;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace TifoXRCoreWebAPI.Tests.Services;
+
+public sealed class RulesEvaluationServiceTests
+{
+    [Fact]
+    public async Task EvaluateAsync_UsesRequestPropertyWhenParameterResolutionFails()
+    {
+        // Arrange
+        var workflowDefinitions = new List<RuntimeWorkflowDefinition>
+        {
+            new()
+            {
+                WorkflowId = 1,
+                WorkflowName = "GamePlayed",
+                EventType = "GamePlayed",
+                Rules = new List<RuntimeRuleDefinition>
+                {
+                    new()
+                    {
+                        RuleId = 1,
+                        RuleName = "DifficultyMatch",
+                        Expression = "input1.Difficulty == 3",
+                        SuccessEvent = "reward:matched"
+                    }
+                },
+                Parameters = new Dictionary<string, RuntimeParameterDefinition>
+                {
+                    ["Difficulty"] = new()
+                    {
+                        Key = "Difficulty",
+                        Source = "event",
+                        Path = "$.difficulty",
+                        IsRequired = false
+                    }
+                }
+            }
+        };
+
+        var repository = new Mock<IRulesRepository>();
+        repository
+            .Setup(r => r.GetRuntimeWorkflowsAsync(It.IsAny<int>()))
+            .ReturnsAsync(workflowDefinitions);
+
+        var logger = new Mock<ILogger<RulesEvaluationService>>();
+        var service = new RulesEvaluationService(repository.Object, logger.Object);
+
+        using var doc = JsonDocument.Parse("""{ \"Difficulty\": 3 }""");
+
+        var request = new RulesEngineEvaluationRequest
+        {
+            SpaceId = 42,
+            EventType = "GamePlayed",
+            OccurredAt = DateTime.UtcNow,
+            Properties = new Dictionary<string, JsonElement>
+            {
+                ["Difficulty"] = doc.RootElement.GetProperty("Difficulty")
+            }
+        };
+
+        // Act
+        var response = await service.EvaluateAsync(request);
+
+        // Assert
+        response.AnyRuleMatched.Should().BeTrue();
+        response.Outcomes.Should().ContainSingle();
+        response.Outcomes[0].IsSuccess.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Summary
- preserve request-provided rule parameters when resolution returns null and add case-insensitive path resolution for event properties
- add unit coverage ensuring request difficulty survives parameter lookup casing mismatches

## Testing
- `dotnet test` *(fails: dotnet CLI is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc4307c9a4832993426bfa51814266