### PR TITLE
Propagate rule execution exceptions to evaluation outcomes

### DIFF
--- a/Services/RulesEvaluationService.cs
+++ b/Services/RulesEvaluationService.cs
@@ -344,12 +344,16 @@ public sealed class RulesEvaluationService : IRulesEvaluationService
         var successEvent = result.Rule.SuccessEvent;
         var rewardCode = TryParseRewardCode(successEvent);
 
+        var errorMessage = string.IsNullOrWhiteSpace(result.ExceptionMessage)
+            ? result.Rule.ErrorMessage
+            : result.ExceptionMessage;
+
         return new RuleEvaluationOutcome
         {
             RuleName = result.Rule.RuleName,
             IsSuccess = result.IsSuccess,
             SuccessEvent = successEvent,
-            ErrorMessage = result.Rule.ErrorMessage,
+            ErrorMessage = errorMessage,
             RewardCode = rewardCode
         };
     }

--- a/TifoXRCoreWebAPI.Tests/Services/RulesEvaluationServiceTests.cs
+++ b/TifoXRCoreWebAPI.Tests/Services/RulesEvaluationServiceTests.cs
@@ -73,4 +73,59 @@ public sealed class RulesEvaluationServiceTests
         response.Outcomes.Should().ContainSingle();
         response.Outcomes[0].IsSuccess.Should().BeTrue();
     }
+
+    [Fact]
+    public async Task EvaluateAsync_PopulatesErrorMessageWhenRuleThrows()
+    {
+        // Arrange
+        const string ExpectedError = "Boom!";
+
+        var workflowDefinitions = new List<RuntimeWorkflowDefinition>
+        {
+            new()
+            {
+                WorkflowId = 1,
+                WorkflowName = "GamePlayed",
+                EventType = "GamePlayed",
+                Rules = new List<RuntimeRuleDefinition>
+                {
+                    new()
+                    {
+                        RuleId = 1,
+                        RuleName = "Throws",
+                        Expression = $"throw new System.Exception(\"{ExpectedError}\")",
+                        SuccessEvent = null,
+                        ErrorMessage = "Fallback error"
+                    }
+                }
+            }
+        };
+
+        var repository = new Mock<IRulesRepository>();
+        repository
+            .Setup(r => r.GetRuntimeWorkflowsAsync(It.IsAny<int>()))
+            .ReturnsAsync(workflowDefinitions);
+
+        var logger = new Mock<ILogger<RulesEvaluationService>>();
+        var service = new RulesEvaluationService(repository.Object, logger.Object);
+
+        var request = new RulesEngineEvaluationRequest
+        {
+            SpaceId = 42,
+            EventType = "GamePlayed",
+            OccurredAt = DateTime.UtcNow
+        };
+
+        // Act
+        var response = await service.EvaluateAsync(request);
+
+        // Assert
+        response.AnyRuleMatched.Should().BeFalse();
+        response.Outcomes.Should().ContainSingle();
+        var outcome = response.Outcomes[0];
+        outcome.IsSuccess.Should().BeFalse();
+        outcome.ErrorMessage.Should().NotBeNull();
+        outcome.ErrorMessage.Should().Contain(ExpectedError);
+        outcome.ErrorMessage.Should().NotBe("Fallback error");
+    }
 }


### PR DESCRIPTION
## Summary
- surface rule execution exception messages on evaluation outcomes so clients can inspect runtime issues
- add a regression test that verifies a throwing rule populates the response error message

## Testing
- dotnet test *(fails: dotnet CLI is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc4e4eb9a88329bc3d6129b6a59456