### PR TITLE
Allow rule parameters without input prefix

### DIFF
--- a/Services/RulesEvaluationService.cs
+++ b/Services/RulesEvaluationService.cs
@@ -63,11 +63,42 @@ public sealed class RulesEvaluationService : IRulesEvaluationService
 
         cache.ParameterMap.TryGetValue(workflowName, out var parameterDefinitions);
 
-        var parameters = new[]
+        var inputBag = BuildPropertyBag(request, parameterDefinitions);
+        var parameters = new List<RuleParameter>
         {
-            new RuleParameter("input1", BuildPropertyBag(request, parameterDefinitions)),
-            new RuleParameter("event", request)
+            new("input1", inputBag),
+            new("event", request)
         };
+
+        if (parameterDefinitions is not null && parameterDefinitions.Count > 0)
+        {
+            var inputDictionary = (IDictionary<string, object?>)inputBag;
+
+            foreach (var (alias, definition) in parameterDefinitions)
+            {
+                if (string.IsNullOrWhiteSpace(alias) ||
+                    string.Equals(alias, "input1", StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(alias, "event", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                object? value = null;
+
+                if (!string.IsNullOrWhiteSpace(alias) && inputDictionary.TryGetValue(alias, out var aliasValue))
+                {
+                    value = aliasValue;
+                }
+                else if (!string.IsNullOrWhiteSpace(definition?.Key) &&
+                         !string.Equals(definition.Key, alias, StringComparison.OrdinalIgnoreCase) &&
+                         inputDictionary.TryGetValue(definition.Key, out var keyValue))
+                {
+                    value = keyValue;
+                }
+
+                parameters.Add(new RuleParameter(alias, value));
+            }
+        }
 
         List<RuleResultTree> results;
 

--- a/TifoXRCoreWebAPI.Tests/Services/RulesEvaluationServiceTests.cs
+++ b/TifoXRCoreWebAPI.Tests/Services/RulesEvaluationServiceTests.cs
@@ -128,4 +128,68 @@ public sealed class RulesEvaluationServiceTests
         outcome.ErrorMessage.Should().Contain(ExpectedError);
         outcome.ErrorMessage.Should().NotBe("Fallback error");
     }
+
+    [Fact]
+    public async Task EvaluateAsync_AllowsParameterReferenceWithoutInputPrefix()
+    {
+        // Arrange
+        var workflowDefinitions = new List<RuntimeWorkflowDefinition>
+        {
+            new()
+            {
+                WorkflowId = 1,
+                WorkflowName = "GamePlayed",
+                EventType = "GamePlayed",
+                Rules = new List<RuntimeRuleDefinition>
+                {
+                    new()
+                    {
+                        RuleId = 1,
+                        RuleName = "ScoreThreshold",
+                        Expression = "ScoreValue >= 50",
+                        SuccessEvent = "reward:threshold"
+                    }
+                },
+                Parameters = new Dictionary<string, RuntimeParameterDefinition>
+                {
+                    ["ScoreValue"] = new()
+                    {
+                        Key = "ScoreValue",
+                        Source = "event",
+                        Path = "$.ScoreValue",
+                        IsRequired = false
+                    }
+                }
+            }
+        };
+
+        var repository = new Mock<IRulesRepository>();
+        repository
+            .Setup(r => r.GetRuntimeWorkflowsAsync(It.IsAny<int>()))
+            .ReturnsAsync(workflowDefinitions);
+
+        var logger = new Mock<ILogger<RulesEvaluationService>>();
+        var service = new RulesEvaluationService(repository.Object, logger.Object);
+
+        using var doc = JsonDocument.Parse("""{ \"ScoreValue\": 75 }""");
+
+        var request = new RulesEngineEvaluationRequest
+        {
+            SpaceId = 42,
+            EventType = "GamePlayed",
+            OccurredAt = DateTime.UtcNow,
+            Properties = new Dictionary<string, JsonElement>
+            {
+                ["ScoreValue"] = doc.RootElement.GetProperty("ScoreValue")
+            }
+        };
+
+        // Act
+        var response = await service.EvaluateAsync(request);
+
+        // Assert
+        response.AnyRuleMatched.Should().BeTrue();
+        response.Outcomes.Should().ContainSingle();
+        response.Outcomes[0].IsSuccess.Should().BeTrue();
+    }
 }


### PR DESCRIPTION
## Summary
- allow rules evaluation to register context parameter aliases alongside the existing input1 bag
- tolerate missing values while creating alias parameters
- add a unit test confirming rules can reference parameters without the input1 prefix

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dc520a87a483299bab98d1293a949e