### PR TITLE
Invalidate rules evaluation cache after authoring changes

### DIFF
--- a/Services/Interfaces/IRulesEvaluationService.cs
+++ b/Services/Interfaces/IRulesEvaluationService.cs
@@ -14,5 +14,6 @@ namespace GMS.TifoXRCoreWebAPI.Services
     public interface IRulesEvaluationService
     {
         Task<RulesEngineEvaluationResponse> EvaluateAsync(RulesEngineEvaluationRequest request, CancellationToken cancellationToken = default);
+        void Invalidate(int spaceId);
     }
 }

--- a/Services/RulesAuthoringService.cs
+++ b/Services/RulesAuthoringService.cs
@@ -5,6 +5,8 @@
 // <date>09/30/2025</date>
 // <summary>Coordinates repository operations for rules engine authoring.</summary>
 
+using System;
+using System.Collections.Generic;
 using GMS.TifoXRCoreWebAPI.Models;
 using GMS.TifoXRCoreWebAPI.Repositories;
 
@@ -14,19 +16,26 @@ namespace GMS.TifoXRCoreWebAPI.Services
     {
         private readonly IRulesRepository _repo;
         private readonly IRewardRepository _rewardRepo;
+        private readonly IRulesEvaluationService _evaluationService;
         private const string DefaultStateTypeName = "Published";
 
-        public RulesAuthoringService(IRulesRepository repo, IRewardRepository rewardRepo)
+        public RulesAuthoringService(
+            IRulesRepository repo,
+            IRewardRepository rewardRepo,
+            IRulesEvaluationService evaluationService)
         {
-            _repo = repo;
-            _rewardRepo = rewardRepo;
+            _repo = repo ?? throw new ArgumentNullException(nameof(repo));
+            _rewardRepo = rewardRepo ?? throw new ArgumentNullException(nameof(rewardRepo));
+            _evaluationService = evaluationService ?? throw new ArgumentNullException(nameof(evaluationService));
         }
 
         public async Task<int> CreateWorkflowAsync(WorkflowCreateDto dto)
         {
             if (dto is null) throw new ArgumentNullException(nameof(dto));
             var stateTypeId = await ResolveStateTypeIdAsync(dto.StateTypeId);
-            return await _repo.CreateWorkflowAsync(dto, stateTypeId);
+            var id = await _repo.CreateWorkflowAsync(dto, stateTypeId);
+            _evaluationService.Invalidate(dto.SpaceId);
+            return id;
         }
 
         public async Task<int> CreateRuleAsync(RuleCreateDto dto)
@@ -41,14 +50,16 @@ namespace GMS.TifoXRCoreWebAPI.Services
                 throw new InvalidOperationException("Rule space id must match the workflow's space id.");
 
             var stateTypeId = await ResolveStateTypeIdAsync(dto.StateTypeId);
-            return await _repo.CreateRuleAsync(dto, stateTypeId);
+            var id = await _repo.CreateRuleAsync(dto, stateTypeId);
+            _evaluationService.Invalidate(dto.SpaceId);
+            return id;
         }
 
         public async Task<IReadOnlyList<int>> AddConditionGroupsAsync(int ruleId, IEnumerable<ConditionGroupCreateDto> groups)
         {
             if (groups is null) throw new ArgumentNullException(nameof(groups));
 
-            var (exists, _, _) = await _repo.TryGetRuleContextAsync(ruleId);
+            var (exists, spaceId, _) = await _repo.TryGetRuleContextAsync(ruleId);
             if (!exists)
                 throw new InvalidOperationException($"Rule {ruleId} does not exist.");
 
@@ -58,14 +69,16 @@ namespace GMS.TifoXRCoreWebAPI.Services
                     throw new InvalidOperationException("Condition group payload rule id must match the route rule id.");
             }
 
-            return await _repo.InsertConditionGroupsAsync(groups);
+            var ids = await _repo.InsertConditionGroupsAsync(groups);
+            _evaluationService.Invalidate(spaceId);
+            return ids;
         }
 
         public async Task<IReadOnlyList<int>> AddConditionsAsync(int groupId, IEnumerable<ConditionCreateDto> conditions)
         {
             if (conditions is null) throw new ArgumentNullException(nameof(conditions));
 
-            var (exists, _, _) = await _repo.TryGetConditionGroupContextAsync(groupId);
+            var (exists, _, spaceId) = await _repo.TryGetConditionGroupContextAsync(groupId);
             if (!exists)
                 throw new InvalidOperationException($"Condition group {groupId} does not exist.");
 
@@ -75,18 +88,22 @@ namespace GMS.TifoXRCoreWebAPI.Services
                     throw new InvalidOperationException("Condition payload group id must match the route group id.");
             }
 
-            return await _repo.InsertConditionsAsync(conditions);
+            var ids = await _repo.InsertConditionsAsync(conditions);
+            _evaluationService.Invalidate(spaceId);
+            return ids;
         }
 
         public async Task<int> CreateRuleActionAsync(RuleActionCreateDto dto)
         {
             if (dto is null) throw new ArgumentNullException(nameof(dto));
 
-            var (ruleExists, _, _) = await _repo.TryGetRuleContextAsync(dto.RuleId);
+            var (ruleExists, spaceId, _) = await _repo.TryGetRuleContextAsync(dto.RuleId);
             if (!ruleExists)
                 throw new InvalidOperationException($"Rule {dto.RuleId} does not exist.");
 
-            return await _repo.CreateRuleActionAsync(dto);
+            var id = await _repo.CreateRuleActionAsync(dto);
+            _evaluationService.Invalidate(spaceId);
+            return id;
         }
 
         public async Task BindRewardAsync(int actionId, int rewardId)

--- a/Services/RulesEvaluationService.cs
+++ b/Services/RulesEvaluationService.cs
@@ -132,6 +132,16 @@ public sealed class RulesEvaluationService : IRulesEvaluationService
         };
     }
 
+    public void Invalidate(int spaceId)
+    {
+        if (spaceId <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(spaceId));
+        }
+
+        _workflowCaches.TryRemove(spaceId, out _);
+    }
+
     private async Task<WorkflowCache> GetWorkflowCacheAsync(int spaceId, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();

--- a/TifoXRCoreWebAPI.Tests/Services/RulesEvaluationServiceTests.cs
+++ b/TifoXRCoreWebAPI.Tests/Services/RulesEvaluationServiceTests.cs
@@ -192,4 +192,117 @@ public sealed class RulesEvaluationServiceTests
         response.Outcomes.Should().ContainSingle();
         response.Outcomes[0].IsSuccess.Should().BeTrue();
     }
+
+    [Fact]
+    public async Task EvaluateAsync_ReloadsCacheAfterInvalidation()
+    {
+        // Arrange
+        var initialDefinitions = new List<RuntimeWorkflowDefinition>
+        {
+            new()
+            {
+                WorkflowId = 1,
+                WorkflowName = "GamePlayed",
+                EventType = "GamePlayed",
+                Rules = new List<RuntimeRuleDefinition>
+                {
+                    new()
+                    {
+                        RuleId = 1,
+                        RuleName = "ScoreThreshold",
+                        Expression = "ScoreValue >= 50",
+                        SuccessEvent = "reward:threshold"
+                    }
+                },
+                Parameters = new Dictionary<string, RuntimeParameterDefinition>
+                {
+                    ["ScoreValue"] = new()
+                    {
+                        Key = "ScoreValue",
+                        Source = "event",
+                        Path = "$.ScoreValue",
+                        IsRequired = false
+                    }
+                }
+            }
+        };
+
+        var updatedDefinitions = new List<RuntimeWorkflowDefinition>
+        {
+            new()
+            {
+                WorkflowId = 1,
+                WorkflowName = "GamePlayed",
+                EventType = "GamePlayed",
+                Rules = new List<RuntimeRuleDefinition>
+                {
+                    new()
+                    {
+                        RuleId = 1,
+                        RuleName = "ScoreThreshold",
+                        Expression = "ScoreValue >= 50",
+                        SuccessEvent = "reward:threshold"
+                    }
+                },
+                Parameters = new Dictionary<string, RuntimeParameterDefinition>
+                {
+                    ["ScoreValue"] = new()
+                    {
+                        Key = "ScoreValue",
+                        Source = "event",
+                        Path = "$.NewScore",
+                        IsRequired = false
+                    }
+                }
+            }
+        };
+
+        var repository = new Mock<IRulesRepository>();
+        repository
+            .SetupSequence(r => r.GetRuntimeWorkflowsAsync(It.IsAny<int>()))
+            .ReturnsAsync(initialDefinitions)
+            .ReturnsAsync(updatedDefinitions);
+
+        var logger = new Mock<ILogger<RulesEvaluationService>>();
+        var service = new RulesEvaluationService(repository.Object, logger.Object);
+
+        using var firstDoc = JsonDocument.Parse("""{ \"ScoreValue\": 75 }""");
+        var firstRequest = new RulesEngineEvaluationRequest
+        {
+            SpaceId = 42,
+            EventType = "GamePlayed",
+            OccurredAt = DateTime.UtcNow,
+            Properties = new Dictionary<string, JsonElement>
+            {
+                ["ScoreValue"] = firstDoc.RootElement.GetProperty("ScoreValue")
+            }
+        };
+
+        // Warm the cache
+        var initialResponse = await service.EvaluateAsync(firstRequest);
+        initialResponse.AnyRuleMatched.Should().BeTrue();
+
+        service.Invalidate(firstRequest.SpaceId);
+
+        using var secondDoc = JsonDocument.Parse("""{ \"NewScore\": 80 }""");
+        var secondRequest = new RulesEngineEvaluationRequest
+        {
+            SpaceId = 42,
+            EventType = "GamePlayed",
+            OccurredAt = DateTime.UtcNow,
+            Properties = new Dictionary<string, JsonElement>
+            {
+                ["NewScore"] = secondDoc.RootElement.GetProperty("NewScore")
+            }
+        };
+
+        // Act
+        var updatedResponse = await service.EvaluateAsync(secondRequest);
+
+        // Assert
+        updatedResponse.AnyRuleMatched.Should().BeTrue();
+        updatedResponse.Outcomes.Should().ContainSingle();
+        updatedResponse.Outcomes[0].IsSuccess.Should().BeTrue();
+        repository.Verify(r => r.GetRuntimeWorkflowsAsync(firstRequest.SpaceId), Times.Exactly(2));
+    }
 }


### PR DESCRIPTION
## Summary
- add an explicit invalidation hook to the rules evaluation service so workflow caches refresh when metadata changes
- trigger cache invalidation from authoring operations that create or mutate workflows, rules, conditions, and actions
- add a regression test to ensure rule evaluation reloads updated context parameter metadata after invalidation

## Testing
- dotnet test *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dc57efc6588329ae2656971e5caf5f