### PR TITLE
Add CRUD endpoints for rules metadata lookups

### DIFF
--- a/Controllers/RulesMetadataController.cs
+++ b/Controllers/RulesMetadataController.cs
@@ -1,0 +1,345 @@
+﻿// <copyright file="RulesMetadataController.cs" company="Global Mobile Software LLC">
+// Copyright © 2025 All Rights Reserved
+// </copyright>
+// <author>Saad Sohail</author>
+// <date>10/01/2025</date>
+// <summary>CRUD endpoints for rules metadata (re_* tables).</summary>
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using GMS.TifoXRCoreWebAPI.Middleware;
+using GMS.TifoXRCoreWebAPI.Middleware.Errors;
+using GMS.TifoXRCoreWebAPI.Models;
+using GMS.TifoXRCoreWebAPI.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GMS.TifoXRCoreWebAPI.Controllers
+{
+    [ApiController]
+    [Route("api/rules/metadata")]
+    [Produces("application/json")]
+    public sealed class RulesMetadataController : ControllerBase
+    {
+        private readonly IRulesMetadataService _svc;
+
+        public RulesMetadataController(IRulesMetadataService svc)
+            => _svc = svc;
+
+        [HttpGet("event-types")]
+        [ProducesResponseType(typeof(IReadOnlyList<EventTypeView>), StatusCodes.Status200OK)]
+        public async Task<ActionResult<IReadOnlyList<EventTypeView>>> GetEventTypes()
+            => Ok(await _svc.GetEventTypesAsync());
+
+        [HttpPost("event-types")]
+        [ProducesResponseType(typeof(object), StatusCodes.Status201Created)]
+        public async Task<ActionResult<object>> CreateEventType([FromBody] EventTypeCreateDto dto)
+        {
+            if (dto is null)
+                throw ErrorService.Exception(
+                    ErrorType.ArgumentNull,
+                    nameof(CreateEventType),
+                    ErrorMessages.Validation.MissingParameter,
+                    paramName: nameof(dto));
+
+            if (string.IsNullOrWhiteSpace(dto.Name))
+                throw ErrorService.Exception(
+                    ErrorType.Argument,
+                    nameof(CreateEventType),
+                    ErrorMessages.Validation.InvalidFormat,
+                    paramName: nameof(dto.Name));
+
+            var id = await _svc.CreateEventTypeAsync(dto);
+            return CreatedAtAction(nameof(CreateEventType), new { id }, new { id });
+        }
+
+        [HttpPut("event-types/{id:int}")]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        public async Task<IActionResult> UpdateEventType(int id, [FromBody] EventTypeUpdateDto dto)
+        {
+            if (id <= 0)
+                throw ErrorService.Exception(
+                    ErrorType.Argument,
+                    nameof(UpdateEventType),
+                    ErrorMessages.Validation.PositiveIntRequired,
+                    paramName: nameof(id),
+                    parameters: new { id });
+
+            if (dto is null)
+                throw ErrorService.Exception(
+                    ErrorType.ArgumentNull,
+                    nameof(UpdateEventType),
+                    ErrorMessages.Validation.MissingParameter,
+                    paramName: nameof(dto),
+                    parameters: new { id });
+
+            if (dto.Id != id)
+                throw ErrorService.Exception(
+                    ErrorType.Argument,
+                    nameof(UpdateEventType),
+                    ErrorMessages.Validation.RouteBodyMismatch,
+                    paramName: nameof(dto.Id),
+                    parameters: new { expected = id, actual = dto.Id });
+
+            if (string.IsNullOrWhiteSpace(dto.Name))
+                throw ErrorService.Exception(
+                    ErrorType.Argument,
+                    nameof(UpdateEventType),
+                    ErrorMessages.Validation.InvalidFormat,
+                    paramName: nameof(dto.Name),
+                    parameters: new { id });
+
+            var updated = await _svc.UpdateEventTypeAsync(dto);
+            if (!updated)
+                throw ErrorService.Exception(
+                    ErrorType.NotFound,
+                    nameof(UpdateEventType),
+                    ErrorMessages.Http.NotFound,
+                    parameters: new { id });
+
+            return NoContent();
+        }
+
+        [HttpGet("context-parameters")]
+        [ProducesResponseType(typeof(IReadOnlyList<ContextParameterView>), StatusCodes.Status200OK)]
+        public async Task<ActionResult<IReadOnlyList<ContextParameterView>>> GetContextParameters()
+            => Ok(await _svc.GetContextParametersAsync());
+
+        [HttpPost("context-parameters")]
+        [ProducesResponseType(typeof(object), StatusCodes.Status201Created)]
+        public async Task<ActionResult<object>> CreateContextParameter([FromBody] ContextParameterCreateDto dto)
+        {
+            if (dto is null)
+                throw ErrorService.Exception(
+                    ErrorType.ArgumentNull,
+                    nameof(CreateContextParameter),
+                    ErrorMessages.Validation.MissingParameter,
+                    paramName: nameof(dto));
+
+            ValidateContextParameterPayload(nameof(CreateContextParameter), dto);
+
+            var id = await _svc.CreateContextParameterAsync(dto);
+            return CreatedAtAction(nameof(CreateContextParameter), new { id }, new { id });
+        }
+
+        [HttpPut("context-parameters/{id:int}")]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        public async Task<IActionResult> UpdateContextParameter(int id, [FromBody] ContextParameterUpdateDto dto)
+        {
+            if (id <= 0)
+                throw ErrorService.Exception(
+                    ErrorType.Argument,
+                    nameof(UpdateContextParameter),
+                    ErrorMessages.Validation.PositiveIntRequired,
+                    paramName: nameof(id),
+                    parameters: new { id });
+
+            if (dto is null)
+                throw ErrorService.Exception(
+                    ErrorType.ArgumentNull,
+                    nameof(UpdateContextParameter),
+                    ErrorMessages.Validation.MissingParameter,
+                    paramName: nameof(dto),
+                    parameters: new { id });
+
+            if (dto.Id != id)
+                throw ErrorService.Exception(
+                    ErrorType.Argument,
+                    nameof(UpdateContextParameter),
+                    ErrorMessages.Validation.RouteBodyMismatch,
+                    paramName: nameof(dto.Id),
+                    parameters: new { expected = id, actual = dto.Id });
+
+            ValidateContextParameterPayload(nameof(UpdateContextParameter), dto);
+
+            var updated = await _svc.UpdateContextParameterAsync(dto);
+            if (!updated)
+                throw ErrorService.Exception(
+                    ErrorType.NotFound,
+                    nameof(UpdateContextParameter),
+                    ErrorMessages.Http.NotFound,
+                    parameters: new { id });
+
+            return NoContent();
+        }
+
+        [HttpGet("event-types/{eventTypeId:int}/parameters")]
+        [ProducesResponseType(typeof(IReadOnlyList<EventTypeParameterView>), StatusCodes.Status200OK)]
+        public async Task<ActionResult<IReadOnlyList<EventTypeParameterView>>> GetEventTypeParameters(int eventTypeId)
+        {
+            if (eventTypeId <= 0)
+                throw ErrorService.Exception(
+                    ErrorType.Argument,
+                    nameof(GetEventTypeParameters),
+                    ErrorMessages.Validation.PositiveIntRequired,
+                    paramName: nameof(eventTypeId),
+                    parameters: new { eventTypeId });
+
+            var rows = await _svc.GetEventTypeParametersAsync(eventTypeId);
+            return Ok(rows);
+        }
+
+        [HttpPost("event-types/{eventTypeId:int}/parameters")]
+        [ProducesResponseType(typeof(object), StatusCodes.Status201Created)]
+        public async Task<ActionResult<object>> CreateEventTypeParameter(int eventTypeId, [FromBody] EventTypeParameterCreateDto dto)
+        {
+            if (eventTypeId <= 0)
+                throw ErrorService.Exception(
+                    ErrorType.Argument,
+                    nameof(CreateEventTypeParameter),
+                    ErrorMessages.Validation.PositiveIntRequired,
+                    paramName: nameof(eventTypeId),
+                    parameters: new { eventTypeId });
+
+            if (dto is null)
+                throw ErrorService.Exception(
+                    ErrorType.ArgumentNull,
+                    nameof(CreateEventTypeParameter),
+                    ErrorMessages.Validation.MissingParameter,
+                    paramName: nameof(dto),
+                    parameters: new { eventTypeId });
+
+            if (dto.ReEventTypeId != eventTypeId)
+                throw ErrorService.Exception(
+                    ErrorType.Argument,
+                    nameof(CreateEventTypeParameter),
+                    ErrorMessages.Validation.RouteBodyMismatch,
+                    paramName: nameof(dto.ReEventTypeId),
+                    parameters: new { expected = eventTypeId, actual = dto.ReEventTypeId });
+
+            ValidateEventTypeParameterPayload(nameof(CreateEventTypeParameter), dto);
+
+            var id = await _svc.CreateEventTypeParameterAsync(dto);
+            return CreatedAtAction(nameof(CreateEventTypeParameter), new { eventTypeId, id }, new { id });
+        }
+
+        [HttpPut("event-type-parameters/{id:int}")]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        public async Task<IActionResult> UpdateEventTypeParameter(int id, [FromBody] EventTypeParameterUpdateDto dto)
+        {
+            if (id <= 0)
+                throw ErrorService.Exception(
+                    ErrorType.Argument,
+                    nameof(UpdateEventTypeParameter),
+                    ErrorMessages.Validation.PositiveIntRequired,
+                    paramName: nameof(id),
+                    parameters: new { id });
+
+            if (dto is null)
+                throw ErrorService.Exception(
+                    ErrorType.ArgumentNull,
+                    nameof(UpdateEventTypeParameter),
+                    ErrorMessages.Validation.MissingParameter,
+                    paramName: nameof(dto),
+                    parameters: new { id });
+
+            if (dto.Id != id)
+                throw ErrorService.Exception(
+                    ErrorType.Argument,
+                    nameof(UpdateEventTypeParameter),
+                    ErrorMessages.Validation.RouteBodyMismatch,
+                    paramName: nameof(dto.Id),
+                    parameters: new { expected = id, actual = dto.Id });
+
+            if (dto.ReEventTypeId <= 0)
+                throw ErrorService.Exception(
+                    ErrorType.Argument,
+                    nameof(UpdateEventTypeParameter),
+                    ErrorMessages.Validation.PositiveIntRequired,
+                    paramName: nameof(dto.ReEventTypeId),
+                    parameters: new { id, dto.ReEventTypeId });
+
+            ValidateEventTypeParameterPayload(nameof(UpdateEventTypeParameter), dto);
+
+            var updated = await _svc.UpdateEventTypeParameterAsync(dto);
+            if (!updated)
+                throw ErrorService.Exception(
+                    ErrorType.NotFound,
+                    nameof(UpdateEventTypeParameter),
+                    ErrorMessages.Http.NotFound,
+                    parameters: new { id });
+
+            return NoContent();
+        }
+
+        private static void ValidateContextParameterPayload(string method, ContextParameterCreateDto dto)
+        {
+            if (string.IsNullOrWhiteSpace(dto.Key))
+                throw ErrorService.Exception(
+                    ErrorType.Argument,
+                    method,
+                    ErrorMessages.Validation.InvalidFormat,
+                    paramName: nameof(dto.Key));
+
+            if (string.IsNullOrWhiteSpace(dto.Source))
+                throw ErrorService.Exception(
+                    ErrorType.Argument,
+                    method,
+                    ErrorMessages.Validation.InvalidFormat,
+                    paramName: nameof(dto.Source));
+
+            if (string.IsNullOrWhiteSpace(dto.Path))
+                throw ErrorService.Exception(
+                    ErrorType.Argument,
+                    method,
+                    ErrorMessages.Validation.InvalidFormat,
+                    paramName: nameof(dto.Path));
+
+            if (dto.RePathTypeId <= 0)
+                throw ErrorService.Exception(
+                    ErrorType.Argument,
+                    method,
+                    ErrorMessages.Validation.PositiveIntRequired,
+                    paramName: nameof(dto.RePathTypeId),
+                    parameters: new { dto.RePathTypeId });
+
+            if (string.IsNullOrWhiteSpace(dto.DataType))
+                throw ErrorService.Exception(
+                    ErrorType.Argument,
+                    method,
+                    ErrorMessages.Validation.InvalidFormat,
+                    paramName: nameof(dto.DataType));
+
+            if (string.IsNullOrWhiteSpace(dto.UiLabel))
+                throw ErrorService.Exception(
+                    ErrorType.Argument,
+                    method,
+                    ErrorMessages.Validation.InvalidFormat,
+                    paramName: nameof(dto.UiLabel));
+
+            if (string.IsNullOrWhiteSpace(dto.UiHelpKey))
+                throw ErrorService.Exception(
+                    ErrorType.Argument,
+                    method,
+                    ErrorMessages.Validation.InvalidFormat,
+                    paramName: nameof(dto.UiHelpKey));
+
+            if (dto.ReDropdownValueProviderId.HasValue && dto.ReDropdownValueProviderId.Value <= 0)
+                throw ErrorService.Exception(
+                    ErrorType.Argument,
+                    method,
+                    ErrorMessages.Validation.PositiveIntRequired,
+                    paramName: nameof(dto.ReDropdownValueProviderId),
+                    parameters: new { dto.ReDropdownValueProviderId });
+        }
+
+        private static void ValidateEventTypeParameterPayload(string method, EventTypeParameterCreateDto dto)
+        {
+            if (dto.ReEventTypeId <= 0)
+                throw ErrorService.Exception(
+                    ErrorType.Argument,
+                    method,
+                    ErrorMessages.Validation.PositiveIntRequired,
+                    paramName: nameof(dto.ReEventTypeId),
+                    parameters: new { dto.ReEventTypeId });
+
+            if (dto.ParameterId <= 0)
+                throw ErrorService.Exception(
+                    ErrorType.Argument,
+                    method,
+                    ErrorMessages.Validation.PositiveIntRequired,
+                    paramName: nameof(dto.ParameterId),
+                    parameters: new { dto.ParameterId });
+        }
+    }
+}

--- a/Models/RulesModels.cs
+++ b/Models/RulesModels.cs
@@ -101,10 +101,15 @@ namespace GMS.TifoXRCoreWebAPI.Models
         public int RePathTypeId { get; init; }
         public string DataType { get; init; } = default!;
         public string UiLabel { get; init; } = default!;
-        public string? UiHelpKey { get; init; }
+        public string UiHelpKey { get; init; } = default!;
         public string? Unit { get; init; }
         public int? ReDropdownValueProviderId { get; init; }
         public string? ExampleValue { get; init; }
+    }
+
+    public sealed class ContextParameterUpdateDto : ContextParameterCreateDto
+    {
+        public int Id { get; init; }
     }
 
     public sealed class ContextParameterView
@@ -116,12 +121,23 @@ namespace GMS.TifoXRCoreWebAPI.Models
         public int RePathTypeId { get; init; }
         public string DataType { get; init; } = default!;
         public string UiLabel { get; init; } = default!;
+        public string UiHelpKey { get; init; } = default!;
         public string? Unit { get; init; }
+        public int? DropdownProviderId { get; init; }
+        public int? ProviderTypeId { get; init; }
+        public string? ProviderType { get; init; }
+        public string? DropdownConfigJson { get; init; }
+        public string? ExampleValue { get; init; }
     }
 
     public sealed class EventTypeCreateDto
     {
         public string Name { get; init; } = default!;
+    }
+
+    public sealed class EventTypeUpdateDto : EventTypeCreateDto
+    {
+        public int Id { get; init; }
     }
 
     public sealed class EventTypeView
@@ -130,11 +146,26 @@ namespace GMS.TifoXRCoreWebAPI.Models
         public string Name { get; init; } = default!;
     }
 
-    public sealed class EventTypeParameterUpsertDto
+    public sealed class EventTypeParameterCreateDto
     {
         public int ReEventTypeId { get; init; }
         public int ParameterId { get; init; }
         public bool IsRequired { get; init; } = true;
+        public string? DefaultValueJson { get; init; }
+    }
+
+    public sealed class EventTypeParameterUpdateDto : EventTypeParameterCreateDto
+    {
+        public int Id { get; init; }
+    }
+
+    public sealed class EventTypeParameterView
+    {
+        public int Id { get; init; }
+        public int EventTypeId { get; init; }
+        public int ParameterId { get; init; }
+        public string ParameterKey { get; init; } = default!;
+        public bool IsRequired { get; init; }
         public string? DefaultValueJson { get; init; }
     }
 

--- a/Program.cs
+++ b/Program.cs
@@ -155,6 +155,7 @@ static void ConfigureServices(IServiceCollection services,  IConfiguration confi
     services.AddScoped<ILookupService, LookupService>();
     services.AddScoped<IRulesAuthoringService, RulesAuthoringService>();
     services.AddScoped<IRulesEvaluationService, RulesEvaluationService>();
+    services.AddScoped<IRulesMetadataService, RulesMetadataService>();
     services.AddScoped<IRewardService, RewardService>();
 
     #endregion

--- a/Repositories/Interfaces/IRulesMetadataRepository.cs
+++ b/Repositories/Interfaces/IRulesMetadataRepository.cs
@@ -1,0 +1,28 @@
+﻿// <copyright file="IRulesMetadataRepository.cs" company="Global Mobile Software LLC">
+// Copyright © 2025 All Rights Reserved
+// </copyright>
+// <author>Saad Sohail</author>
+// <date>10/01/2025</date>
+// <summary>Data access for rules metadata tables (re_* lookups).</summary>
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using GMS.TifoXRCoreWebAPI.Models;
+
+namespace GMS.TifoXRCoreWebAPI.Repositories
+{
+    public interface IRulesMetadataRepository
+    {
+        Task<IReadOnlyList<EventTypeView>> GetEventTypesAsync();
+        Task<int> InsertEventTypeAsync(EventTypeCreateDto dto);
+        Task<bool> UpdateEventTypeAsync(EventTypeUpdateDto dto);
+
+        Task<IReadOnlyList<ContextParameterView>> GetContextParametersAsync();
+        Task<int> InsertContextParameterAsync(ContextParameterCreateDto dto);
+        Task<bool> UpdateContextParameterAsync(ContextParameterUpdateDto dto);
+
+        Task<IReadOnlyList<EventTypeParameterView>> GetEventTypeParametersAsync(int eventTypeId);
+        Task<int> InsertEventTypeParameterAsync(EventTypeParameterCreateDto dto);
+        Task<bool> UpdateEventTypeParameterAsync(EventTypeParameterUpdateDto dto);
+    }
+}

--- a/Repositories/RulesMetadataRepository.cs
+++ b/Repositories/RulesMetadataRepository.cs
@@ -1,0 +1,206 @@
+﻿// <copyright file="RulesMetadataRepository.cs" company="Global Mobile Software LLC">
+// Copyright © 2025 All Rights Reserved
+// </copyright>
+// <author>Saad Sohail</author>
+// <date>10/01/2025</date>
+// <summary>CRUD operations for rules metadata (re_*) tables.</summary>
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using GMS.TifoXRCoreWebAPI.Models;
+using GMS.TifoXRCoreWebAPI.Repositories.Sql;
+using GMS.TifoXRCoreWebAPI.Utilities.Infrastructure;
+
+namespace GMS.TifoXRCoreWebAPI.Repositories
+{
+    public sealed class RulesMetadataRepository : IRulesMetadataRepository
+    {
+        private readonly IDbProvider _db;
+
+        public RulesMetadataRepository(IDbProvider db)
+            => _db = db ?? throw new ArgumentNullException(nameof(db));
+
+        public async Task<IReadOnlyList<EventTypeView>> GetEventTypesAsync()
+        {
+            var list = new List<EventTypeView>();
+
+            await using var conn = await _db.OpenConnectionAsync();
+            await using var cmd = _db.CreateCommand(conn, RulesMetadataSql.SelectEventTypes);
+            await using var rdr = await cmd.ExecuteReaderAsync();
+
+            while (await rdr.ReadAsync())
+            {
+                list.Add(new EventTypeView
+                {
+                    Id = rdr.GetInt32(rdr.GetOrdinal("Id")),
+                    Name = rdr.GetString(rdr.GetOrdinal("Name"))
+                });
+            }
+
+            return list;
+        }
+
+        public async Task<int> InsertEventTypeAsync(EventTypeCreateDto dto)
+        {
+            if (dto is null) throw new ArgumentNullException(nameof(dto));
+
+            await using var conn = await _db.OpenConnectionAsync();
+            await using var cmd = _db.CreateCommand(conn, RulesMetadataSql.InsertEventType);
+            cmd.Parameters.Add(_db.CreateParameter("@Name", dto.Name));
+
+            var obj = await cmd.ExecuteScalarAsync();
+            return Convert.ToInt32(obj);
+        }
+
+        public async Task<bool> UpdateEventTypeAsync(EventTypeUpdateDto dto)
+        {
+            if (dto is null) throw new ArgumentNullException(nameof(dto));
+
+            await using var conn = await _db.OpenConnectionAsync();
+            await using var cmd = _db.CreateCommand(conn, RulesMetadataSql.UpdateEventType);
+            cmd.Parameters.Add(_db.CreateParameter("@Id", dto.Id));
+            cmd.Parameters.Add(_db.CreateParameter("@Name", dto.Name));
+
+            var affected = await cmd.ExecuteNonQueryAsync();
+            return affected > 0;
+        }
+
+        public async Task<IReadOnlyList<ContextParameterView>> GetContextParametersAsync()
+        {
+            var list = new List<ContextParameterView>();
+
+            await using var conn = await _db.OpenConnectionAsync();
+            await using var cmd = _db.CreateCommand(conn, RulesMetadataSql.SelectContextParameters);
+            await using var rdr = await cmd.ExecuteReaderAsync();
+
+            while (await rdr.ReadAsync())
+            {
+                var dropdownProviderIdOrdinal = rdr.GetOrdinal("DropdownProviderId");
+                var providerTypeIdOrdinal = rdr.GetOrdinal("ProviderTypeId");
+                var providerTypeOrdinal = rdr.GetOrdinal("ProviderType");
+                var dropdownConfigOrdinal = rdr.GetOrdinal("DropdownConfigJson");
+                var exampleValueOrdinal = rdr.GetOrdinal("ExampleValue");
+
+                list.Add(new ContextParameterView
+                {
+                    Id = rdr.GetInt32(rdr.GetOrdinal("Id")),
+                    Key = rdr.GetString(rdr.GetOrdinal("Key")),
+                    Source = rdr.GetString(rdr.GetOrdinal("Source")),
+                    Path = rdr.GetString(rdr.GetOrdinal("Path")),
+                    RePathTypeId = rdr.GetInt32(rdr.GetOrdinal("RePathTypeId")),
+                    DataType = rdr.GetString(rdr.GetOrdinal("DataType")),
+                    UiLabel = rdr.GetString(rdr.GetOrdinal("UiLabel")),
+                    UiHelpKey = rdr.GetString(rdr.GetOrdinal("UiHelpKey")),
+                    Unit = rdr.IsDBNull(rdr.GetOrdinal("Unit")) ? null : rdr.GetString(rdr.GetOrdinal("Unit")),
+                    DropdownProviderId = rdr.IsDBNull(dropdownProviderIdOrdinal) ? null : rdr.GetInt32(dropdownProviderIdOrdinal),
+                    ProviderTypeId = rdr.IsDBNull(providerTypeIdOrdinal) ? null : rdr.GetInt32(providerTypeIdOrdinal),
+                    ProviderType = rdr.IsDBNull(providerTypeOrdinal) ? null : rdr.GetString(providerTypeOrdinal),
+                    DropdownConfigJson = rdr.IsDBNull(dropdownConfigOrdinal) ? null : rdr.GetString(dropdownConfigOrdinal),
+                    ExampleValue = rdr.IsDBNull(exampleValueOrdinal) ? null : rdr.GetString(exampleValueOrdinal)
+                });
+            }
+
+            return list;
+        }
+
+        public async Task<int> InsertContextParameterAsync(ContextParameterCreateDto dto)
+        {
+            if (dto is null) throw new ArgumentNullException(nameof(dto));
+
+            await using var conn = await _db.OpenConnectionAsync();
+            await using var cmd = _db.CreateCommand(conn, RulesMetadataSql.InsertContextParameter);
+            cmd.Parameters.Add(_db.CreateParameter("@Key", dto.Key));
+            cmd.Parameters.Add(_db.CreateParameter("@Source", dto.Source));
+            cmd.Parameters.Add(_db.CreateParameter("@Path", dto.Path));
+            cmd.Parameters.Add(_db.CreateParameter("@RePathTypeId", dto.RePathTypeId));
+            cmd.Parameters.Add(_db.CreateParameter("@DataType", dto.DataType));
+            cmd.Parameters.Add(_db.CreateParameter("@UiLabel", dto.UiLabel));
+            cmd.Parameters.Add(_db.CreateParameter("@UiHelpKey", dto.UiHelpKey));
+            cmd.Parameters.Add(_db.CreateParameter("@Unit", dto.Unit));
+            cmd.Parameters.Add(_db.CreateParameter("@DropdownProviderId", dto.ReDropdownValueProviderId));
+            cmd.Parameters.Add(_db.CreateParameter("@ExampleValue", dto.ExampleValue));
+
+            var obj = await cmd.ExecuteScalarAsync();
+            return Convert.ToInt32(obj);
+        }
+
+        public async Task<bool> UpdateContextParameterAsync(ContextParameterUpdateDto dto)
+        {
+            if (dto is null) throw new ArgumentNullException(nameof(dto));
+
+            await using var conn = await _db.OpenConnectionAsync();
+            await using var cmd = _db.CreateCommand(conn, RulesMetadataSql.UpdateContextParameter);
+            cmd.Parameters.Add(_db.CreateParameter("@Id", dto.Id));
+            cmd.Parameters.Add(_db.CreateParameter("@Key", dto.Key));
+            cmd.Parameters.Add(_db.CreateParameter("@Source", dto.Source));
+            cmd.Parameters.Add(_db.CreateParameter("@Path", dto.Path));
+            cmd.Parameters.Add(_db.CreateParameter("@RePathTypeId", dto.RePathTypeId));
+            cmd.Parameters.Add(_db.CreateParameter("@DataType", dto.DataType));
+            cmd.Parameters.Add(_db.CreateParameter("@UiLabel", dto.UiLabel));
+            cmd.Parameters.Add(_db.CreateParameter("@UiHelpKey", dto.UiHelpKey));
+            cmd.Parameters.Add(_db.CreateParameter("@Unit", dto.Unit));
+            cmd.Parameters.Add(_db.CreateParameter("@DropdownProviderId", dto.ReDropdownValueProviderId));
+            cmd.Parameters.Add(_db.CreateParameter("@ExampleValue", dto.ExampleValue));
+
+            var affected = await cmd.ExecuteNonQueryAsync();
+            return affected > 0;
+        }
+
+        public async Task<IReadOnlyList<EventTypeParameterView>> GetEventTypeParametersAsync(int eventTypeId)
+        {
+            var list = new List<EventTypeParameterView>();
+
+            await using var conn = await _db.OpenConnectionAsync();
+            await using var cmd = _db.CreateCommand(conn, RulesMetadataSql.SelectEventTypeParameters);
+            cmd.Parameters.Add(_db.CreateParameter("@EventTypeId", eventTypeId));
+
+            await using var rdr = await cmd.ExecuteReaderAsync();
+            while (await rdr.ReadAsync())
+            {
+                list.Add(new EventTypeParameterView
+                {
+                    Id = rdr.GetInt32(rdr.GetOrdinal("Id")),
+                    EventTypeId = rdr.GetInt32(rdr.GetOrdinal("EventTypeId")),
+                    ParameterId = rdr.GetInt32(rdr.GetOrdinal("ParameterId")),
+                    ParameterKey = rdr.GetString(rdr.GetOrdinal("ParameterKey")),
+                    IsRequired = rdr.GetInt32(rdr.GetOrdinal("IsRequired")) == 1,
+                    DefaultValueJson = rdr.IsDBNull(rdr.GetOrdinal("DefaultValueJson")) ? null : rdr.GetString(rdr.GetOrdinal("DefaultValueJson"))
+                });
+            }
+
+            return list;
+        }
+
+        public async Task<int> InsertEventTypeParameterAsync(EventTypeParameterCreateDto dto)
+        {
+            if (dto is null) throw new ArgumentNullException(nameof(dto));
+
+            await using var conn = await _db.OpenConnectionAsync();
+            await using var cmd = _db.CreateCommand(conn, RulesMetadataSql.InsertEventTypeParameter);
+            cmd.Parameters.Add(_db.CreateParameter("@EventTypeId", dto.ReEventTypeId));
+            cmd.Parameters.Add(_db.CreateParameter("@ParameterId", dto.ParameterId));
+            cmd.Parameters.Add(_db.CreateParameter("@IsRequired", dto.IsRequired ? 1 : 0));
+            cmd.Parameters.Add(_db.CreateParameter("@DefaultValueJson", dto.DefaultValueJson));
+
+            var obj = await cmd.ExecuteScalarAsync();
+            return Convert.ToInt32(obj);
+        }
+
+        public async Task<bool> UpdateEventTypeParameterAsync(EventTypeParameterUpdateDto dto)
+        {
+            if (dto is null) throw new ArgumentNullException(nameof(dto));
+
+            await using var conn = await _db.OpenConnectionAsync();
+            await using var cmd = _db.CreateCommand(conn, RulesMetadataSql.UpdateEventTypeParameter);
+            cmd.Parameters.Add(_db.CreateParameter("@Id", dto.Id));
+            cmd.Parameters.Add(_db.CreateParameter("@EventTypeId", dto.ReEventTypeId));
+            cmd.Parameters.Add(_db.CreateParameter("@ParameterId", dto.ParameterId));
+            cmd.Parameters.Add(_db.CreateParameter("@IsRequired", dto.IsRequired ? 1 : 0));
+            cmd.Parameters.Add(_db.CreateParameter("@DefaultValueJson", dto.DefaultValueJson));
+
+            var affected = await cmd.ExecuteNonQueryAsync();
+            return affected > 0;
+        }
+    }
+}

--- a/Repositories/Sql/RulesMetadataSql.cs
+++ b/Repositories/Sql/RulesMetadataSql.cs
@@ -1,0 +1,101 @@
+﻿// <copyright file="RulesMetadataSql.cs" company="Global Mobile Software LLC">
+// Copyright © 2025 All Rights Reserved
+// </copyright>
+// <author>Saad Sohail</author>
+// <date>10/01/2025</date>
+// <summary>SQL statements for rules metadata CRUD operations.</summary>
+
+namespace GMS.TifoXRCoreWebAPI.Repositories.Sql
+{
+    public static class RulesMetadataSql
+    {
+        public const string SelectEventTypes = @"
+            SELECT id AS Id, name AS Name
+            FROM re_event_type
+            ORDER BY id;";
+
+        public const string InsertEventType = @"
+            INSERT INTO re_event_type (name, creation_time, modified_by)
+            VALUES (@Name, NOW(6), 'system');
+            SELECT LAST_INSERT_ID();";
+
+        public const string UpdateEventType = @"
+            UPDATE re_event_type
+            SET name = @Name,
+                modified_by = 'system'
+            WHERE id = @Id;";
+
+        public const string SelectContextParameters = @"
+            SELECT cp.id AS Id,
+                   cp.`key` AS `Key`,
+                   cp.source AS Source,
+                   cp.path AS Path,
+                   cp.re_path_type_id AS RePathTypeId,
+                   cp.data_type AS DataType,
+                   cp.ui_label AS UiLabel,
+                   cp.ui_help_key AS UiHelpKey,
+                   cp.unit AS Unit,
+                   cp.re_dropdown_value_provider_id AS DropdownProviderId,
+                   d.re_provider_type_id AS ProviderTypeId,
+                   pt.type AS ProviderType,
+                   d.config_json AS DropdownConfigJson,
+                   cp.example_value AS ExampleValue
+            FROM re_context_parameter cp
+            LEFT JOIN re_dropdown_value_provider d ON d.id = cp.re_dropdown_value_provider_id
+            LEFT JOIN re_provider_type pt ON pt.id = d.re_provider_type_id
+            ORDER BY cp.id;";
+
+        public const string InsertContextParameter = @"
+            INSERT INTO re_context_parameter
+                (`key`, source, path, re_path_type_id, data_type,
+                 ui_label, ui_help_key, unit, re_dropdown_value_provider_id,
+                 example_value, creation_time, modified_by)
+            VALUES
+                (@Key, @Source, @Path, @RePathTypeId, @DataType,
+                 @UiLabel, @UiHelpKey, @Unit, @DropdownProviderId,
+                 @ExampleValue, NOW(6), 'system');
+            SELECT LAST_INSERT_ID();";
+
+        public const string UpdateContextParameter = @"
+            UPDATE re_context_parameter
+            SET `key` = @Key,
+                source = @Source,
+                path = @Path,
+                re_path_type_id = @RePathTypeId,
+                data_type = @DataType,
+                ui_label = @UiLabel,
+                ui_help_key = @UiHelpKey,
+                unit = @Unit,
+                re_dropdown_value_provider_id = @DropdownProviderId,
+                example_value = @ExampleValue,
+                modified_by = 'system'
+            WHERE id = @Id;";
+
+        public const string SelectEventTypeParameters = @"
+            SELECT etp.id AS Id,
+                   etp.re_event_type_id AS EventTypeId,
+                   etp.parameter_id AS ParameterId,
+                   cp.`key` AS ParameterKey,
+                   (etp.is_required + 0) AS IsRequired,
+                   etp.default_value_json AS DefaultValueJson
+            FROM re_event_type_parameter etp
+            JOIN re_context_parameter cp ON cp.id = etp.parameter_id
+            WHERE etp.re_event_type_id = @EventTypeId
+            ORDER BY etp.id;";
+
+        public const string InsertEventTypeParameter = @"
+            INSERT INTO re_event_type_parameter
+                (re_event_type_id, parameter_id, is_required, default_value_json, creation_time, modified_by)
+            VALUES (@EventTypeId, @ParameterId, @IsRequired, @DefaultValueJson, NOW(6), 'system');
+            SELECT LAST_INSERT_ID();";
+
+        public const string UpdateEventTypeParameter = @"
+            UPDATE re_event_type_parameter
+            SET re_event_type_id = @EventTypeId,
+                parameter_id = @ParameterId,
+                is_required = @IsRequired,
+                default_value_json = @DefaultValueJson,
+                modified_by = 'system'
+            WHERE id = @Id;";
+    }
+}

--- a/Services/Interfaces/IRulesMetadataService.cs
+++ b/Services/Interfaces/IRulesMetadataService.cs
@@ -1,0 +1,28 @@
+﻿// <copyright file="IRulesMetadataService.cs" company="Global Mobile Software LLC">
+// Copyright © 2025 All Rights Reserved
+// </copyright>
+// <author>Saad Sohail</author>
+// <date>10/01/2025</date>
+// <summary>Application service for rules metadata management.</summary>
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using GMS.TifoXRCoreWebAPI.Models;
+
+namespace GMS.TifoXRCoreWebAPI.Services
+{
+    public interface IRulesMetadataService
+    {
+        Task<IReadOnlyList<EventTypeView>> GetEventTypesAsync();
+        Task<int> CreateEventTypeAsync(EventTypeCreateDto dto);
+        Task<bool> UpdateEventTypeAsync(EventTypeUpdateDto dto);
+
+        Task<IReadOnlyList<ContextParameterView>> GetContextParametersAsync();
+        Task<int> CreateContextParameterAsync(ContextParameterCreateDto dto);
+        Task<bool> UpdateContextParameterAsync(ContextParameterUpdateDto dto);
+
+        Task<IReadOnlyList<EventTypeParameterView>> GetEventTypeParametersAsync(int eventTypeId);
+        Task<int> CreateEventTypeParameterAsync(EventTypeParameterCreateDto dto);
+        Task<bool> UpdateEventTypeParameterAsync(EventTypeParameterUpdateDto dto);
+    }
+}

--- a/Services/RulesMetadataService.cs
+++ b/Services/RulesMetadataService.cs
@@ -1,0 +1,68 @@
+﻿// <copyright file="RulesMetadataService.cs" company="Global Mobile Software LLC">
+// Copyright © 2025 All Rights Reserved
+// </copyright>
+// <author>Saad Sohail</author>
+// <date>10/01/2025</date>
+// <summary>Coordinates metadata repository operations for rule authoring.</summary>
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using GMS.TifoXRCoreWebAPI.Models;
+using GMS.TifoXRCoreWebAPI.Repositories;
+
+namespace GMS.TifoXRCoreWebAPI.Services
+{
+    public sealed class RulesMetadataService : IRulesMetadataService
+    {
+        private readonly IRulesMetadataRepository _repo;
+
+        public RulesMetadataService(IRulesMetadataRepository repo)
+            => _repo = repo ?? throw new ArgumentNullException(nameof(repo));
+
+        public Task<IReadOnlyList<EventTypeView>> GetEventTypesAsync()
+            => _repo.GetEventTypesAsync();
+
+        public Task<int> CreateEventTypeAsync(EventTypeCreateDto dto)
+        {
+            if (dto is null) throw new ArgumentNullException(nameof(dto));
+            return _repo.InsertEventTypeAsync(dto);
+        }
+
+        public Task<bool> UpdateEventTypeAsync(EventTypeUpdateDto dto)
+        {
+            if (dto is null) throw new ArgumentNullException(nameof(dto));
+            return _repo.UpdateEventTypeAsync(dto);
+        }
+
+        public Task<IReadOnlyList<ContextParameterView>> GetContextParametersAsync()
+            => _repo.GetContextParametersAsync();
+
+        public Task<int> CreateContextParameterAsync(ContextParameterCreateDto dto)
+        {
+            if (dto is null) throw new ArgumentNullException(nameof(dto));
+            return _repo.InsertContextParameterAsync(dto);
+        }
+
+        public Task<bool> UpdateContextParameterAsync(ContextParameterUpdateDto dto)
+        {
+            if (dto is null) throw new ArgumentNullException(nameof(dto));
+            return _repo.UpdateContextParameterAsync(dto);
+        }
+
+        public Task<IReadOnlyList<EventTypeParameterView>> GetEventTypeParametersAsync(int eventTypeId)
+            => _repo.GetEventTypeParametersAsync(eventTypeId);
+
+        public Task<int> CreateEventTypeParameterAsync(EventTypeParameterCreateDto dto)
+        {
+            if (dto is null) throw new ArgumentNullException(nameof(dto));
+            return _repo.InsertEventTypeParameterAsync(dto);
+        }
+
+        public Task<bool> UpdateEventTypeParameterAsync(EventTypeParameterUpdateDto dto)
+        {
+            if (dto is null) throw new ArgumentNullException(nameof(dto));
+            return _repo.UpdateEventTypeParameterAsync(dto);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated RulesMetadataController exposing GET, POST, and PUT endpoints for rules event types, context parameters, and event type parameters
- implement repository, service, and SQL layers to persist re_* metadata tables used by the authoring experience
- extend existing rules DTOs to support create/update payloads and register the new metadata service in DI

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68de832bbfec83299b87871131dbf3dd