### PR TITLE
Add rule detail endpoints and expression regeneration

### DIFF
--- a/Controllers/RulesAuthoringController.cs
+++ b/Controllers/RulesAuthoringController.cs
@@ -44,6 +44,49 @@ namespace GMS.TifoXRCoreWebAPI.Controllers
             return CreatedAtAction(nameof(CreateWorkflow), new { id }, new { id });
         }
 
+        [HttpGet("rules/{ruleId:int}")]
+        [ProducesResponseType(typeof(RuleDetailView), StatusCodes.Status200OK)]
+        public async Task<ActionResult<RuleDetailView>> GetRule(int spaceId, int ruleId)
+        {
+            var detail = await _svc.GetRuleDetailAsync(spaceId, ruleId);
+            return Ok(detail);
+        }
+
+        [HttpPut("rules/{ruleId:int}")]
+        [ProducesResponseType(typeof(RuleExpressionUpdateResult), StatusCodes.Status200OK)]
+        public async Task<ActionResult<RuleExpressionUpdateResult>> UpdateRule(
+            int spaceId,
+            int ruleId,
+            [FromBody] RuleDefinitionUpdateDto dto)
+        {
+            if (dto is null)
+                throw ErrorService.Exception(
+                    ErrorType.ArgumentNull,
+                    nameof(UpdateRule),
+                    ErrorMessages.Validation.MissingParameter,
+                    paramName: nameof(dto),
+                    parameters: new { spaceId, ruleId });
+
+            if (dto.RuleId != ruleId)
+                throw ErrorService.Exception(
+                    ErrorType.Argument,
+                    nameof(UpdateRule),
+                    ErrorMessages.Validation.RouteBodyMismatch,
+                    paramName: nameof(dto.RuleId),
+                    parameters: new { expected = ruleId, actual = dto.RuleId });
+
+            if (dto.SpaceId != spaceId)
+                throw ErrorService.Exception(
+                    ErrorType.Argument,
+                    nameof(UpdateRule),
+                    ErrorMessages.Validation.RouteBodyMismatch,
+                    paramName: nameof(dto.SpaceId),
+                    parameters: new { expected = spaceId, actual = dto.SpaceId });
+
+            var result = await _svc.UpdateRuleDefinitionAsync(dto);
+            return Ok(result);
+        }
+
         [HttpPost("workflows/{workflowId:int}/rules")]
         [ProducesResponseType(typeof(object), StatusCodes.Status201Created)]
         public async Task<ActionResult<object>> CreateRule(int workflowId, [FromBody] RuleCreateDto dto)

--- a/Models/RulesModels.cs
+++ b/Models/RulesModels.cs
@@ -89,6 +89,35 @@ namespace GMS.TifoXRCoreWebAPI.Models
         public int StateTypeId { get; init; }
     }
 
+    public sealed class RuleDetailRecord
+    {
+        public int RuleId { get; init; }
+        public int WorkflowId { get; init; }
+        public int SpaceId { get; init; }
+        public string RuleName { get; init; } = default!;
+        public string WorkflowName { get; init; } = default!;
+        public string? Expression { get; init; }
+        public string? TargetType { get; init; }
+        public string? SuccessEvent { get; init; }
+        public int Priority { get; init; }
+        public int RuleCooldownSeconds { get; init; }
+        public int StateTypeId { get; init; }
+        public int? Version { get; init; }
+        public int? ParentRuleId { get; init; }
+        public int? EventTypeId { get; init; }
+    }
+
+    public sealed class RuleDetailView
+    {
+        public RuleDetailRecord Rule { get; init; } = default!;
+        public IReadOnlyList<ConditionGroupDetailView> ConditionGroups { get; init; }
+            = Array.Empty<ConditionGroupDetailView>();
+        public IReadOnlyList<ConditionDetailView> Conditions { get; init; }
+            = Array.Empty<ConditionDetailView>();
+        public IReadOnlyList<EventTypeParameterView> EventTypeParameters { get; init; }
+            = Array.Empty<EventTypeParameterView>();
+    }
+
     // =========================
     // Authoring: Parameters & Event Types
     // =========================
@@ -192,6 +221,12 @@ namespace GMS.TifoXRCoreWebAPI.Models
         public int OrderIndex { get; init; }
     }
 
+    public sealed class ConditionGroupDetailView : ConditionGroupView
+    {
+        public string LogicalOperatorCode { get; init; } = default!;
+        public string LogicalOperatorFormat { get; init; } = default!;
+    }
+
     public sealed class ConditionCreateDto
     {
         public int GroupId { get; init; }
@@ -213,6 +248,32 @@ namespace GMS.TifoXRCoreWebAPI.Models
         public string RightValueKind { get; init; } = default!;
         public string? RightValueJson { get; init; }
         public int OrderIndex { get; init; }
+    }
+
+    public sealed class ConditionDetailView : ConditionView
+    {
+        public string ComparatorCode { get; init; } = default!;
+        public string ComparatorFormat { get; init; } = default!;
+        public string ParameterKey { get; init; } = default!;
+        public string ParameterSource { get; init; } = default!;
+        public string ParameterPath { get; init; } = default!;
+    }
+
+    public sealed class RuleDefinitionUpdateDto
+    {
+        public int RuleId { get; init; }
+        public int SpaceId { get; init; }
+        public string RuleName { get; init; } = default!;
+        public string? TargetType { get; init; }
+        public string? SuccessEvent { get; init; }
+        public int Priority { get; init; } = 100;
+        public int RuleCooldownSeconds { get; init; }
+    }
+
+    public sealed class RuleExpressionUpdateResult
+    {
+        public int RuleId { get; init; }
+        public string Expression { get; init; } = string.Empty;
     }
 
     // =========================

--- a/Repositories/Interfaces/IRulesRepository.cs
+++ b/Repositories/Interfaces/IRulesRepository.cs
@@ -20,6 +20,12 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
         Task<bool> ActionBelongsToRuleAsync(int actionId, int ruleId);
         Task<int?> GetStateTypeIdByNameAsync(string type);
 
+        Task<RuleDetailRecord?> GetRuleDetailAsync(int ruleId);
+        Task<IReadOnlyList<ConditionGroupDetailView>> GetRuleConditionGroupsAsync(int ruleId);
+        Task<IReadOnlyList<ConditionDetailView>> GetRuleConditionsAsync(int ruleId);
+
+        Task UpdateRuleDefinitionAsync(RuleDefinitionUpdateDto dto, string expression);
+
         Task<int> CreateWorkflowAsync(WorkflowCreateDto dto, int stateTypeId);
         Task<int> CreateRuleAsync(RuleCreateDto dto, int stateTypeId);
         Task<IReadOnlyList<int>> InsertConditionGroupsAsync(IEnumerable<ConditionGroupCreateDto> dtos);

--- a/Repositories/RulesRepository.cs
+++ b/Repositories/RulesRepository.cs
@@ -181,6 +181,144 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
             return stateTypeId;
         }
 
+        public async Task<RuleDetailRecord?> GetRuleDetailAsync(int ruleId)
+        {
+            _logger.LogDebug("Fetching rule detail for rule {RuleId}.", ruleId);
+            await using var conn = await _db.OpenConnectionAsync();
+            await using var cmd = _db.CreateCommand(conn, RulesSql.GetRuleDetail);
+            cmd.Parameters.Add(_db.CreateParameter("@RuleId", ruleId));
+
+            await using var rdr = await cmd.ExecuteReaderAsync();
+            if (!await rdr.ReadAsync())
+            {
+                _logger.LogDebug("Rule detail not found for rule {RuleId}.", ruleId);
+                return null;
+            }
+
+            var record = new RuleDetailRecord
+            {
+                RuleId = rdr.GetInt32(rdr.GetOrdinal("RuleId")),
+                WorkflowId = rdr.GetInt32(rdr.GetOrdinal("WorkflowId")),
+                SpaceId = rdr.GetInt32(rdr.GetOrdinal("SpaceId")),
+                RuleName = rdr.GetString(rdr.GetOrdinal("RuleName")),
+                WorkflowName = rdr.GetString(rdr.GetOrdinal("WorkflowName")),
+                Expression = rdr.IsDBNull(rdr.GetOrdinal("Expression")) ? null : rdr.GetString(rdr.GetOrdinal("Expression")),
+                TargetType = rdr.IsDBNull(rdr.GetOrdinal("TargetType")) ? null : rdr.GetString(rdr.GetOrdinal("TargetType")),
+                SuccessEvent = rdr.IsDBNull(rdr.GetOrdinal("SuccessEvent")) ? null : rdr.GetString(rdr.GetOrdinal("SuccessEvent")),
+                Priority = rdr.GetInt32(rdr.GetOrdinal("Priority")),
+                RuleCooldownSeconds = rdr.GetInt32(rdr.GetOrdinal("RuleCooldownSeconds")),
+                StateTypeId = rdr.GetInt32(rdr.GetOrdinal("StateTypeId")),
+                Version = rdr.IsDBNull(rdr.GetOrdinal("Version")) ? null : rdr.GetInt32(rdr.GetOrdinal("Version")),
+                ParentRuleId = rdr.IsDBNull(rdr.GetOrdinal("ParentRuleId")) ? null : rdr.GetInt32(rdr.GetOrdinal("ParentRuleId")),
+                EventTypeId = rdr.IsDBNull(rdr.GetOrdinal("EventTypeId")) ? null : rdr.GetInt32(rdr.GetOrdinal("EventTypeId"))
+            };
+
+            _logger.LogDebug(
+                "Fetched rule detail for rule {RuleId} with workflow {WorkflowId} in space {SpaceId}.",
+                record.RuleId,
+                record.WorkflowId,
+                record.SpaceId);
+
+            return record;
+        }
+
+        public async Task<IReadOnlyList<ConditionGroupDetailView>> GetRuleConditionGroupsAsync(int ruleId)
+        {
+            _logger.LogDebug("Fetching condition groups for rule {RuleId}.", ruleId);
+            await using var conn = await _db.OpenConnectionAsync();
+            await using var cmd = _db.CreateCommand(conn, RulesSql.GetRuleConditionGroups);
+            cmd.Parameters.Add(_db.CreateParameter("@RuleId", ruleId));
+
+            var list = new List<ConditionGroupDetailView>();
+
+            await using var rdr = await cmd.ExecuteReaderAsync();
+            while (await rdr.ReadAsync())
+            {
+                list.Add(new ConditionGroupDetailView
+                {
+                    Id = rdr.GetInt32(rdr.GetOrdinal("Id")),
+                    RuleId = rdr.GetInt32(rdr.GetOrdinal("RuleId")),
+                    ParentGroupId = rdr.IsDBNull(rdr.GetOrdinal("ParentGroupId"))
+                        ? null
+                        : rdr.GetInt32(rdr.GetOrdinal("ParentGroupId")),
+                    LogicalOperatorId = rdr.GetInt32(rdr.GetOrdinal("LogicalOperatorId")),
+                    OrderIndex = rdr.GetInt32(rdr.GetOrdinal("OrderIndex")),
+                    LogicalOperatorCode = rdr.GetString(rdr.GetOrdinal("LogicalOperatorCode")),
+                    LogicalOperatorFormat = rdr.GetString(rdr.GetOrdinal("LogicalOperatorFormat"))
+                });
+            }
+
+            _logger.LogDebug(
+                "Fetched {Count} condition groups for rule {RuleId}.",
+                list.Count,
+                ruleId);
+
+            return list;
+        }
+
+        public async Task<IReadOnlyList<ConditionDetailView>> GetRuleConditionsAsync(int ruleId)
+        {
+            _logger.LogDebug("Fetching conditions for rule {RuleId}.", ruleId);
+            await using var conn = await _db.OpenConnectionAsync();
+            await using var cmd = _db.CreateCommand(conn, RulesSql.GetRuleConditions);
+            cmd.Parameters.Add(_db.CreateParameter("@RuleId", ruleId));
+
+            var list = new List<ConditionDetailView>();
+
+            await using var rdr = await cmd.ExecuteReaderAsync();
+            while (await rdr.ReadAsync())
+            {
+                list.Add(new ConditionDetailView
+                {
+                    Id = rdr.GetInt32(rdr.GetOrdinal("Id")),
+                    GroupId = rdr.GetInt32(rdr.GetOrdinal("GroupId")),
+                    ParameterId = rdr.GetInt32(rdr.GetOrdinal("ParameterId")),
+                    ComparatorId = rdr.GetInt32(rdr.GetOrdinal("ComparatorId")),
+                    Negate = rdr.GetInt32(rdr.GetOrdinal("Negate")) == 1,
+                    RightValueKind = rdr.GetString(rdr.GetOrdinal("RightValueKind")),
+                    RightValueJson = rdr.IsDBNull(rdr.GetOrdinal("RightValueJson"))
+                        ? null
+                        : rdr.GetString(rdr.GetOrdinal("RightValueJson")),
+                    OrderIndex = rdr.GetInt32(rdr.GetOrdinal("OrderIndex")),
+                    ComparatorCode = rdr.GetString(rdr.GetOrdinal("ComparatorCode")),
+                    ComparatorFormat = rdr.GetString(rdr.GetOrdinal("ComparatorFormat")),
+                    ParameterKey = rdr.GetString(rdr.GetOrdinal("ParameterKey")),
+                    ParameterSource = rdr.GetString(rdr.GetOrdinal("ParameterSource")),
+                    ParameterPath = rdr.GetString(rdr.GetOrdinal("ParameterPath"))
+                });
+            }
+
+            _logger.LogDebug(
+                "Fetched {Count} conditions for rule {RuleId}.",
+                list.Count,
+                ruleId);
+
+            return list;
+        }
+
+        public async Task UpdateRuleDefinitionAsync(RuleDefinitionUpdateDto dto, string expression)
+        {
+            if (dto is null) throw new ArgumentNullException(nameof(dto));
+
+            _logger.LogInformation(
+                "Updating rule {RuleId} definition with payload {Payload} and expression {Expression}.",
+                dto.RuleId,
+                Serialize(dto),
+                expression);
+
+            await using var conn = await _db.OpenConnectionAsync();
+            await using var cmd = _db.CreateCommand(conn, RulesSql.UpdateRuleDefinition);
+            cmd.Parameters.Add(_db.CreateParameter("@RuleId", dto.RuleId));
+            cmd.Parameters.Add(_db.CreateParameter("@RuleName", dto.RuleName));
+            cmd.Parameters.Add(_db.CreateParameter("@TargetType", (object?)dto.TargetType ?? DBNull.Value));
+            cmd.Parameters.Add(_db.CreateParameter("@SuccessEvent", (object?)dto.SuccessEvent ?? DBNull.Value));
+            cmd.Parameters.Add(_db.CreateParameter("@Priority", dto.Priority));
+            cmd.Parameters.Add(_db.CreateParameter("@RuleCooldownSeconds", dto.RuleCooldownSeconds));
+            cmd.Parameters.Add(_db.CreateParameter("@Expression", expression ?? string.Empty));
+
+            await cmd.ExecuteNonQueryAsync();
+        }
+
         public async Task<int> CreateWorkflowAsync(WorkflowCreateDto dto, int stateTypeId)
         {
             if (dto is null) throw new ArgumentNullException(nameof(dto));

--- a/Repositories/Sql/RulesSql.cs
+++ b/Repositories/Sql/RulesSql.cs
@@ -41,6 +41,78 @@ namespace GMS.TifoXRCoreWebAPI.Repositories.Sql
         public const string GetStateTypeIdByName = @"
             SELECT id FROM state_type WHERE type = @Type LIMIT 1;";
 
+        public const string GetRuleDetail = @"
+            SELECT r.id AS RuleId,
+                   r.workflow_id AS WorkflowId,
+                   r.space_id AS SpaceId,
+                   r.rule_name AS RuleName,
+                   r.expression AS Expression,
+                   r.target_type AS TargetType,
+                   r.success_event AS SuccessEvent,
+                   r.priority AS Priority,
+                   r.rule_cooldown_seconds AS RuleCooldownSeconds,
+                   r.state_type_id AS StateTypeId,
+                   r.version AS Version,
+                   r.parent_rule_id AS ParentRuleId,
+                   w.name AS WorkflowName,
+                   et.id AS EventTypeId
+            FROM rules r
+            JOIN workflow w ON w.id = r.workflow_id
+            LEFT JOIN re_event_type et ON et.name = r.target_type
+            WHERE r.id = @RuleId
+            LIMIT 1;";
+
+        public const string GetRuleConditionGroups = @"
+            SELECT g.id AS Id,
+                   g.rule_id AS RuleId,
+                   g.parent_group_id AS ParentGroupId,
+                   g.re_logical_operator_id AS LogicalOperatorId,
+                   g.order_index AS OrderIndex,
+                   lo.code AS LogicalOperatorCode,
+                   lo.engine_format AS LogicalOperatorFormat
+            FROM rule_condition_group g
+            JOIN re_logical_operator lo ON lo.id = g.re_logical_operator_id
+            WHERE g.rule_id = @RuleId
+            ORDER BY CASE WHEN g.parent_group_id IS NULL THEN 0 ELSE 1 END,
+                     g.parent_group_id,
+                     g.order_index,
+                     g.id;";
+
+        public const string GetRuleConditions = @"
+            SELECT rc.id AS Id,
+                   rc.group_id AS GroupId,
+                   rc.parameter_id AS ParameterId,
+                   rc.comparator_id AS ComparatorId,
+                   (rc.negate + 0) AS Negate,
+                   rc.right_value_kind AS RightValueKind,
+                   rc.right_value_json AS RightValueJson,
+                   rc.order_index AS OrderIndex,
+                   cmp.code AS ComparatorCode,
+                   cmp.engine_format AS ComparatorFormat,
+                   cp.`key` AS ParameterKey,
+                   cp.source AS ParameterSource,
+                   cp.path AS ParameterPath
+            FROM rule_condition rc
+            JOIN rule_condition_group rcg ON rcg.id = rc.group_id
+            JOIN re_comparator cmp ON cmp.id = rc.comparator_id
+            JOIN re_context_parameter cp ON cp.id = rc.parameter_id
+            WHERE rcg.rule_id = @RuleId
+            ORDER BY rc.group_id,
+                     rc.order_index,
+                     rc.id;";
+
+        public const string UpdateRuleDefinition = @"
+            UPDATE rules
+            SET rule_name = @RuleName,
+                target_type = @TargetType,
+                success_event = @SuccessEvent,
+                priority = @Priority,
+                rule_cooldown_seconds = @RuleCooldownSeconds,
+                expression = @Expression,
+                modified_time = NOW(6),
+                modified_by = 'system'
+            WHERE id = @RuleId;";
+
         public const string InsertWorkflow = @"
             INSERT INTO workflow (space_id, name, state_type_id, creation_time, modified_by)
             VALUES (@SpaceId, @Name, @StateTypeId, NOW(6), 'system');

--- a/Services/Interfaces/IRulesAuthoringService.cs
+++ b/Services/Interfaces/IRulesAuthoringService.cs
@@ -12,6 +12,8 @@ namespace GMS.TifoXRCoreWebAPI.Services
 {
     public interface IRulesAuthoringService
     {
+        Task<RuleDetailView> GetRuleDetailAsync(int spaceId, int ruleId);
+        Task<RuleExpressionUpdateResult> UpdateRuleDefinitionAsync(RuleDefinitionUpdateDto dto);
         Task<int> CreateWorkflowAsync(WorkflowCreateDto dto);
         Task<int> CreateRuleAsync(RuleCreateDto dto);
         Task<IReadOnlyList<int>> AddConditionGroupsAsync(int ruleId, IEnumerable<ConditionGroupCreateDto> groups);

--- a/Services/RulesAuthoringService.cs
+++ b/Services/RulesAuthoringService.cs
@@ -7,6 +7,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text.Json;
 using GMS.TifoXRCoreWebAPI.Models;
 using GMS.TifoXRCoreWebAPI.Repositories;
 
@@ -17,16 +20,73 @@ namespace GMS.TifoXRCoreWebAPI.Services
         private readonly IRulesRepository _repo;
         private readonly IRewardRepository _rewardRepo;
         private readonly IRulesEvaluationService _evaluationService;
+        private readonly IRulesMetadataRepository _metadataRepo;
         private const string DefaultStateTypeName = "Published";
 
         public RulesAuthoringService(
             IRulesRepository repo,
             IRewardRepository rewardRepo,
-            IRulesEvaluationService evaluationService)
+            IRulesEvaluationService evaluationService,
+            IRulesMetadataRepository metadataRepo)
         {
             _repo = repo ?? throw new ArgumentNullException(nameof(repo));
             _rewardRepo = rewardRepo ?? throw new ArgumentNullException(nameof(rewardRepo));
             _evaluationService = evaluationService ?? throw new ArgumentNullException(nameof(evaluationService));
+            _metadataRepo = metadataRepo ?? throw new ArgumentNullException(nameof(metadataRepo));
+        }
+
+        public async Task<RuleDetailView> GetRuleDetailAsync(int spaceId, int ruleId)
+        {
+            var rule = await _repo.GetRuleDetailAsync(ruleId);
+            if (rule is null)
+                throw new InvalidOperationException($"Rule {ruleId} does not exist.");
+
+            if (rule.SpaceId != spaceId)
+                throw new InvalidOperationException(
+                    $"Rule {ruleId} belongs to space {rule.SpaceId} and cannot be accessed from space {spaceId}.");
+
+            var groups = await _repo.GetRuleConditionGroupsAsync(ruleId);
+            var conditions = await _repo.GetRuleConditionsAsync(ruleId);
+
+            IReadOnlyList<EventTypeParameterView> eventTypeParameters = Array.Empty<EventTypeParameterView>();
+            if (rule.EventTypeId.HasValue)
+            {
+                eventTypeParameters = await _metadataRepo.GetEventTypeParametersAsync(rule.EventTypeId.Value);
+            }
+
+            return new RuleDetailView
+            {
+                Rule = rule,
+                ConditionGroups = groups,
+                Conditions = conditions,
+                EventTypeParameters = eventTypeParameters
+            };
+        }
+
+        public async Task<RuleExpressionUpdateResult> UpdateRuleDefinitionAsync(RuleDefinitionUpdateDto dto)
+        {
+            if (dto is null) throw new ArgumentNullException(nameof(dto));
+
+            var (exists, spaceId, _) = await _repo.TryGetRuleContextAsync(dto.RuleId);
+            if (!exists)
+                throw new InvalidOperationException($"Rule {dto.RuleId} does not exist.");
+
+            if (spaceId != dto.SpaceId)
+                throw new InvalidOperationException(
+                    $"Rule {dto.RuleId} belongs to space {spaceId} and cannot be updated from space {dto.SpaceId}.");
+
+            var groups = await _repo.GetRuleConditionGroupsAsync(dto.RuleId);
+            var conditions = await _repo.GetRuleConditionsAsync(dto.RuleId);
+            var expression = ComposeExpression(groups, conditions);
+
+            await _repo.UpdateRuleDefinitionAsync(dto, expression);
+            _evaluationService.Invalidate(spaceId);
+
+            return new RuleExpressionUpdateResult
+            {
+                RuleId = dto.RuleId,
+                Expression = expression
+            };
         }
 
         public async Task<int> CreateWorkflowAsync(WorkflowCreateDto dto)
@@ -129,6 +189,173 @@ namespace GMS.TifoXRCoreWebAPI.Services
                 throw new InvalidOperationException($"State type '{DefaultStateTypeName}' is not configured.");
 
             return fallback.Value;
+        }
+
+        private static string ComposeExpression(
+            IReadOnlyList<ConditionGroupDetailView> groups,
+            IReadOnlyList<ConditionDetailView> conditions)
+        {
+            if (groups is null || groups.Count == 0)
+            {
+                var conditionExpressions = conditions
+                    .OrderBy(c => c.OrderIndex)
+                    .ThenBy(c => c.Id)
+                    .Select(ComposeCondition)
+                    .Where(static expr => !string.IsNullOrWhiteSpace(expr))
+                    .ToList();
+
+                return CombineUsingFormat("({0} && {1})", conditionExpressions);
+            }
+
+            var groupedChildren = groups
+                .GroupBy(g => g.ParentGroupId)
+                .ToDictionary(
+                    g => g.Key,
+                    g => g.OrderBy(x => x.OrderIndex).ThenBy(x => x.Id).ToList());
+
+            var conditionLookup = conditions
+                .GroupBy(c => c.GroupId)
+                .ToDictionary(
+                    g => g.Key,
+                    g => g.OrderBy(x => x.OrderIndex).ThenBy(x => x.Id).ToList());
+
+            var rootGroups = groups
+                .Where(g => g.ParentGroupId is null)
+                .OrderBy(g => g.OrderIndex)
+                .ThenBy(g => g.Id)
+                .ToList();
+
+            var rootExpressions = new List<string>();
+            foreach (var root in rootGroups)
+            {
+                var expr = ComposeGroup(root, groupedChildren, conditionLookup);
+                if (!string.IsNullOrWhiteSpace(expr))
+                {
+                    rootExpressions.Add(expr);
+                }
+            }
+
+            return CombineUsingFormat("({0} && {1})", rootExpressions);
+        }
+
+        private static string ComposeGroup(
+            ConditionGroupDetailView group,
+            IReadOnlyDictionary<int?, List<ConditionGroupDetailView>> groupedChildren,
+            IReadOnlyDictionary<int, List<ConditionDetailView>> conditionLookup)
+        {
+            var parts = new List<string>();
+
+            if (conditionLookup.TryGetValue(group.Id, out var groupConditions))
+            {
+                foreach (var condition in groupConditions)
+                {
+                    var expr = ComposeCondition(condition);
+                    if (!string.IsNullOrWhiteSpace(expr))
+                    {
+                        parts.Add(expr);
+                    }
+                }
+            }
+
+            if (groupedChildren.TryGetValue(group.Id, out var childGroups))
+            {
+                foreach (var child in childGroups)
+                {
+                    var expr = ComposeGroup(child, groupedChildren, conditionLookup);
+                    if (!string.IsNullOrWhiteSpace(expr))
+                    {
+                        parts.Add(expr);
+                    }
+                }
+            }
+
+            if (parts.Count == 0)
+            {
+                return string.Empty;
+            }
+
+            var format = string.IsNullOrWhiteSpace(group.LogicalOperatorFormat)
+                ? "({0} && {1})"
+                : group.LogicalOperatorFormat;
+
+            return CombineUsingFormat(format, parts);
+        }
+
+        private static string ComposeCondition(ConditionDetailView condition)
+        {
+            var format = string.IsNullOrWhiteSpace(condition.ComparatorFormat)
+                ? "{0} == {1}"
+                : condition.ComparatorFormat;
+
+            var left = condition.ParameterKey;
+            var right = FormatRightValue(condition);
+            var expression = string.Format(CultureInfo.InvariantCulture, format, left, right);
+
+            return condition.Negate ? $"!({expression})" : expression;
+        }
+
+        private static string CombineUsingFormat(string format, IReadOnlyList<string> expressions)
+        {
+            if (expressions.Count == 0)
+            {
+                return string.Empty;
+            }
+
+            if (expressions.Count == 1)
+            {
+                return expressions[0];
+            }
+
+            var result = expressions[0];
+            for (var i = 1; i < expressions.Count; i++)
+            {
+                result = string.Format(CultureInfo.InvariantCulture, format, result, expressions[i]);
+            }
+
+            return result;
+        }
+
+        private static string FormatRightValue(ConditionDetailView condition)
+        {
+            if (string.IsNullOrWhiteSpace(condition.RightValueJson))
+            {
+                return "null";
+            }
+
+            if (string.Equals(condition.RightValueKind, RightValueKinds.Parameter, StringComparison.OrdinalIgnoreCase))
+            {
+                try
+                {
+                    using var doc = JsonDocument.Parse(condition.RightValueJson);
+                    var root = doc.RootElement;
+
+                    if (root.ValueKind == JsonValueKind.String)
+                    {
+                        return root.GetString() ?? "null";
+                    }
+
+                    if (root.ValueKind == JsonValueKind.Object)
+                    {
+                        if (root.TryGetProperty("parameterKey", out var key))
+                        {
+                            return key.GetString() ?? "null";
+                        }
+
+                        if (root.TryGetProperty("key", out var alt))
+                        {
+                            return alt.GetString() ?? "null";
+                        }
+                    }
+                }
+                catch (JsonException)
+                {
+                    return condition.RightValueJson.Trim();
+                }
+
+                return "null";
+            }
+
+            return condition.RightValueJson.Trim();
         }
     }
 }

--- a/TifoXRCoreWebAPI.Tests/Services/RulesAuthoringServiceTests.cs
+++ b/TifoXRCoreWebAPI.Tests/Services/RulesAuthoringServiceTests.cs
@@ -1,0 +1,187 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FluentAssertions;
+using GMS.TifoXRCoreWebAPI.Models;
+using GMS.TifoXRCoreWebAPI.Repositories;
+using GMS.TifoXRCoreWebAPI.Services;
+using Moq;
+using Xunit;
+
+namespace TifoXRCoreWebAPI.Tests.Services
+{
+    public class RulesAuthoringServiceTests
+    {
+        [Fact]
+        public async Task UpdateRuleDefinitionAsync_ComposesExpressionFromConditions()
+        {
+            var repo = new Mock<IRulesRepository>();
+            var rewardRepo = new Mock<IRewardRepository>();
+            var evaluation = new Mock<IRulesEvaluationService>();
+            var metadata = new Mock<IRulesMetadataRepository>();
+
+            repo
+                .Setup(r => r.TryGetRuleContextAsync(1))
+                .ReturnsAsync((true, 42, 7));
+
+            repo
+                .Setup(r => r.GetRuleConditionGroupsAsync(1))
+                .ReturnsAsync(new List<ConditionGroupDetailView>
+                {
+                    new()
+                    {
+                        Id = 100,
+                        RuleId = 1,
+                        ParentGroupId = null,
+                        LogicalOperatorId = 1,
+                        LogicalOperatorCode = "and",
+                        LogicalOperatorFormat = "({0} && {1})",
+                        OrderIndex = 1
+                    }
+                });
+
+            repo
+                .Setup(r => r.GetRuleConditionsAsync(1))
+                .ReturnsAsync(new List<ConditionDetailView>
+                {
+                    new()
+                    {
+                        Id = 200,
+                        GroupId = 100,
+                        ParameterId = 10,
+                        ComparatorId = 5,
+                        ComparatorCode = ComparatorCodes.Gte,
+                        ComparatorFormat = "{0} >= {1}",
+                        ParameterKey = "ScoreValue",
+                        ParameterSource = "event",
+                        ParameterPath = "$.ScoreValue",
+                        Negate = false,
+                        RightValueKind = RightValueKinds.Literal,
+                        RightValueJson = "50",
+                        OrderIndex = 1
+                    }
+                });
+
+            repo
+                .Setup(r => r.UpdateRuleDefinitionAsync(It.IsAny<RuleDefinitionUpdateDto>(), It.IsAny<string>()))
+                .Returns(Task.CompletedTask);
+
+            var service = new RulesAuthoringService(
+                repo.Object,
+                rewardRepo.Object,
+                evaluation.Object,
+                metadata.Object);
+
+            var dto = new RuleDefinitionUpdateDto
+            {
+                RuleId = 1,
+                SpaceId = 42,
+                RuleName = "Test Rule",
+                Priority = 1,
+                RuleCooldownSeconds = 0
+            };
+
+            var result = await service.UpdateRuleDefinitionAsync(dto);
+
+            result.Expression.Should().Be("ScoreValue >= 50");
+            repo.Verify(r => r.UpdateRuleDefinitionAsync(dto, "ScoreValue >= 50"), Times.Once);
+            evaluation.Verify(e => e.Invalidate(42), Times.Once);
+        }
+
+        [Fact]
+        public async Task GetRuleDetailAsync_ReturnsAggregatedView()
+        {
+            var repo = new Mock<IRulesRepository>();
+            var rewardRepo = new Mock<IRewardRepository>();
+            var evaluation = new Mock<IRulesEvaluationService>();
+            var metadata = new Mock<IRulesMetadataRepository>();
+
+            repo
+                .Setup(r => r.GetRuleDetailAsync(1))
+                .ReturnsAsync(new RuleDetailRecord
+                {
+                    RuleId = 1,
+                    WorkflowId = 9,
+                    SpaceId = 42,
+                    RuleName = "Test Rule",
+                    WorkflowName = "Workflow",
+                    Expression = "ScoreValue >= 50",
+                    TargetType = "game.session.ended",
+                    SuccessEvent = "reward:granted",
+                    Priority = 10,
+                    RuleCooldownSeconds = 0,
+                    StateTypeId = 3,
+                    Version = 1,
+                    ParentRuleId = null,
+                    EventTypeId = 7
+                });
+
+            repo
+                .Setup(r => r.GetRuleConditionGroupsAsync(1))
+                .ReturnsAsync(new List<ConditionGroupDetailView>
+                {
+                    new()
+                    {
+                        Id = 100,
+                        RuleId = 1,
+                        ParentGroupId = null,
+                        LogicalOperatorId = 1,
+                        LogicalOperatorCode = "and",
+                        LogicalOperatorFormat = "({0} && {1})",
+                        OrderIndex = 1
+                    }
+                });
+
+            repo
+                .Setup(r => r.GetRuleConditionsAsync(1))
+                .ReturnsAsync(new List<ConditionDetailView>
+                {
+                    new()
+                    {
+                        Id = 200,
+                        GroupId = 100,
+                        ParameterId = 10,
+                        ComparatorId = 5,
+                        ComparatorCode = ComparatorCodes.Gte,
+                        ComparatorFormat = "{0} >= {1}",
+                        ParameterKey = "ScoreValue",
+                        ParameterSource = "event",
+                        ParameterPath = "$.ScoreValue",
+                        Negate = false,
+                        RightValueKind = RightValueKinds.Literal,
+                        RightValueJson = "50",
+                        OrderIndex = 1
+                    }
+                });
+
+            metadata
+                .Setup(m => m.GetEventTypeParametersAsync(7))
+                .ReturnsAsync(new List<EventTypeParameterView>
+                {
+                    new()
+                    {
+                        Id = 300,
+                        EventTypeId = 7,
+                        ParameterId = 10,
+                        ParameterKey = "ScoreValue",
+                        IsRequired = true,
+                        DefaultValueJson = null
+                    }
+                });
+
+            var service = new RulesAuthoringService(
+                repo.Object,
+                rewardRepo.Object,
+                evaluation.Object,
+                metadata.Object);
+
+            var result = await service.GetRuleDetailAsync(42, 1);
+
+            result.Rule.RuleId.Should().Be(1);
+            result.Rule.WorkflowName.Should().Be("Workflow");
+            result.ConditionGroups.Should().HaveCount(1);
+            result.Conditions.Should().HaveCount(1);
+            result.EventTypeParameters.Should().ContainSingle()
+                .Which.ParameterKey.Should().Be("ScoreValue");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add authoring endpoints to retrieve rule details and update a rule while regenerating its expression
- extend repository and service layers to aggregate condition metadata and compose expressions from the stored condition tree
- cover the new behaviour with unit tests for rule detail retrieval and expression composition logic

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68de93468884832994780a9414f5412d