### PR TITLE
Add update endpoints for rule condition entities

### DIFF
--- a/Controllers/RulesAuthoringController.cs
+++ b/Controllers/RulesAuthoringController.cs
@@ -151,6 +151,76 @@ namespace GMS.TifoXRCoreWebAPI.Controllers
             return Ok(new { ids });
         }
 
+        [HttpPut("rules/{ruleId:int}/condition-groups/{groupId:int}")]
+        [ProducesResponseType(typeof(RuleExpressionUpdateResult), StatusCodes.Status200OK)]
+        public async Task<ActionResult<RuleExpressionUpdateResult>> UpdateConditionGroup(
+            int ruleId,
+            int groupId,
+            [FromBody] ConditionGroupUpdateDto dto)
+        {
+            if (dto is null)
+                throw ErrorService.Exception(
+                    ErrorType.ArgumentNull,
+                    nameof(UpdateConditionGroup),
+                    ErrorMessages.Validation.MissingParameter,
+                    paramName: nameof(dto),
+                    parameters: new { ruleId, groupId });
+
+            if (dto.Id != groupId)
+                throw ErrorService.Exception(
+                    ErrorType.Argument,
+                    nameof(UpdateConditionGroup),
+                    ErrorMessages.Validation.RouteBodyMismatch,
+                    paramName: nameof(dto.Id),
+                    parameters: new { expected = groupId, actual = dto.Id });
+
+            if (dto.RuleId != ruleId)
+                throw ErrorService.Exception(
+                    ErrorType.Argument,
+                    nameof(UpdateConditionGroup),
+                    ErrorMessages.Validation.RouteBodyMismatch,
+                    paramName: nameof(dto.RuleId),
+                    parameters: new { expected = ruleId, actual = dto.RuleId });
+
+            var result = await _svc.UpdateConditionGroupAsync(dto);
+            return Ok(result);
+        }
+
+        [HttpPut("condition-groups/{groupId:int}/conditions/{conditionId:int}")]
+        [ProducesResponseType(typeof(RuleExpressionUpdateResult), StatusCodes.Status200OK)]
+        public async Task<ActionResult<RuleExpressionUpdateResult>> UpdateCondition(
+            int groupId,
+            int conditionId,
+            [FromBody] ConditionUpdateDto dto)
+        {
+            if (dto is null)
+                throw ErrorService.Exception(
+                    ErrorType.ArgumentNull,
+                    nameof(UpdateCondition),
+                    ErrorMessages.Validation.MissingParameter,
+                    paramName: nameof(dto),
+                    parameters: new { groupId, conditionId });
+
+            if (dto.Id != conditionId)
+                throw ErrorService.Exception(
+                    ErrorType.Argument,
+                    nameof(UpdateCondition),
+                    ErrorMessages.Validation.RouteBodyMismatch,
+                    paramName: nameof(dto.Id),
+                    parameters: new { expected = conditionId, actual = dto.Id });
+
+            if (dto.GroupId != groupId)
+                throw ErrorService.Exception(
+                    ErrorType.Argument,
+                    nameof(UpdateCondition),
+                    ErrorMessages.Validation.RouteBodyMismatch,
+                    paramName: nameof(dto.GroupId),
+                    parameters: new { expected = groupId, actual = dto.GroupId });
+
+            var result = await _svc.UpdateConditionAsync(dto);
+            return Ok(result);
+        }
+
         [HttpPost("rules/{ruleId:int}/actions")]
         [ProducesResponseType(typeof(object), StatusCodes.Status201Created)]
         public async Task<ActionResult<object>> CreateRuleAction(int ruleId, [FromBody] RuleActionCreateDto dto)

--- a/Models/RulesModels.cs
+++ b/Models/RulesModels.cs
@@ -210,6 +210,11 @@ namespace GMS.TifoXRCoreWebAPI.Models
         public string? DescriptionKey { get; init; }
     }
 
+    public sealed class ConditionGroupUpdateDto : ConditionGroupCreateDto
+    {
+        public int Id { get; init; }
+    }
+
     public class ConditionGroupView
     {
         public int Id { get; init; }
@@ -234,6 +239,11 @@ namespace GMS.TifoXRCoreWebAPI.Models
         public string RightValueKind { get; init; } = RightValueKinds.Literal;
         public string? RightValueJson { get; init; }
         public int OrderIndex { get; init; } = 1;
+    }
+
+    public sealed class ConditionUpdateDto : ConditionCreateDto
+    {
+        public int Id { get; init; }
     }
 
     public class ConditionView

--- a/Repositories/Interfaces/IRulesRepository.cs
+++ b/Repositories/Interfaces/IRulesRepository.cs
@@ -16,6 +16,7 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
         Task<(bool exists, int spaceId, int workflowId)> TryGetRuleContextAsync(int ruleId);
         Task<(bool exists, int ruleId, int spaceId)> TryGetActionContextAsync(int actionId);
         Task<(bool exists, int ruleId, int spaceId)> TryGetConditionGroupContextAsync(int groupId);
+        Task<(bool exists, int groupId, int ruleId, int spaceId)> TryGetConditionContextAsync(int conditionId);
         Task<bool> ConditionGroupBelongsToRuleAsync(int groupId, int ruleId);
         Task<bool> ActionBelongsToRuleAsync(int actionId, int ruleId);
         Task<int?> GetStateTypeIdByNameAsync(string type);
@@ -30,6 +31,9 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
         Task<int> CreateRuleAsync(RuleCreateDto dto, int stateTypeId);
         Task<IReadOnlyList<int>> InsertConditionGroupsAsync(IEnumerable<ConditionGroupCreateDto> dtos);
         Task<IReadOnlyList<int>> InsertConditionsAsync(IEnumerable<ConditionCreateDto> dtos);
+        Task UpdateConditionGroupAsync(ConditionGroupUpdateDto dto);
+        Task UpdateConditionAsync(ConditionUpdateDto dto);
+        Task UpdateRuleExpressionAsync(int ruleId, string expression);
         Task<int> CreateRuleActionAsync(RuleActionCreateDto dto);
         Task BindRewardToActionAsync(int actionId, int rewardId);
 

--- a/Repositories/RulesRepository.cs
+++ b/Repositories/RulesRepository.cs
@@ -126,6 +126,32 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
             return (true, ruleId, spaceId);
         }
 
+        public async Task<(bool exists, int groupId, int ruleId, int spaceId)> TryGetConditionContextAsync(int conditionId)
+        {
+            _logger.LogDebug("Fetching condition context for condition {ConditionId}.", conditionId);
+            await using var conn = await _db.OpenConnectionAsync();
+            await using var cmd = _db.CreateCommand(conn, RulesSql.GetConditionContext);
+            cmd.Parameters.Add(_db.CreateParameter("@Id", conditionId));
+
+            await using var rdr = await cmd.ExecuteReaderAsync();
+            if (!await rdr.ReadAsync())
+            {
+                _logger.LogDebug("Condition context not found for condition {ConditionId}.", conditionId);
+                return (false, 0, 0, 0);
+            }
+
+            var groupId = rdr.GetInt32(rdr.GetOrdinal("GroupId"));
+            var ruleId = rdr.GetInt32(rdr.GetOrdinal("RuleId"));
+            var spaceId = rdr.GetInt32(rdr.GetOrdinal("SpaceId"));
+            _logger.LogDebug(
+                "Condition context for condition {ConditionId}: GroupId={GroupId}, RuleId={RuleId}, SpaceId={SpaceId}.",
+                conditionId,
+                groupId,
+                ruleId,
+                spaceId);
+            return (true, groupId, ruleId, spaceId);
+        }
+
         public async Task<bool> ConditionGroupBelongsToRuleAsync(int groupId, int ruleId)
         {
             _logger.LogDebug(
@@ -461,6 +487,63 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
                 Serialize(ids),
                 Serialize(dtoList));
             return ids;
+        }
+
+        public async Task UpdateConditionGroupAsync(ConditionGroupUpdateDto dto)
+        {
+            if (dto is null) throw new ArgumentNullException(nameof(dto));
+
+            _logger.LogInformation(
+                "Updating condition group {GroupId} with payload {Payload}.",
+                dto.Id,
+                Serialize(dto));
+
+            await using var conn = await _db.OpenConnectionAsync();
+            await using var cmd = _db.CreateCommand(conn, RulesSql.UpdateConditionGroup);
+            cmd.Parameters.Add(_db.CreateParameter("@Id", dto.Id));
+            cmd.Parameters.Add(_db.CreateParameter("@ParentGroupId", (object?)dto.ParentGroupId ?? DBNull.Value));
+            cmd.Parameters.Add(_db.CreateParameter("@LogicalOperatorId", dto.LogicalOperatorId));
+            cmd.Parameters.Add(_db.CreateParameter("@OrderIndex", dto.OrderIndex));
+
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        public async Task UpdateConditionAsync(ConditionUpdateDto dto)
+        {
+            if (dto is null) throw new ArgumentNullException(nameof(dto));
+
+            _logger.LogInformation(
+                "Updating condition {ConditionId} with payload {Payload}.",
+                dto.Id,
+                Serialize(dto));
+
+            await using var conn = await _db.OpenConnectionAsync();
+            await using var cmd = _db.CreateCommand(conn, RulesSql.UpdateCondition);
+            cmd.Parameters.Add(_db.CreateParameter("@Id", dto.Id));
+            cmd.Parameters.Add(_db.CreateParameter("@GroupId", dto.GroupId));
+            cmd.Parameters.Add(_db.CreateParameter("@ParameterId", dto.ParameterId));
+            cmd.Parameters.Add(_db.CreateParameter("@ComparatorId", dto.ComparatorId));
+            cmd.Parameters.Add(_db.CreateParameter("@Negate", dto.Negate ? 1 : 0));
+            cmd.Parameters.Add(_db.CreateParameter("@RightValueKind", dto.RightValueKind));
+            cmd.Parameters.Add(_db.CreateParameter("@RightValueJson", (object?)dto.RightValueJson ?? DBNull.Value));
+            cmd.Parameters.Add(_db.CreateParameter("@OrderIndex", dto.OrderIndex));
+
+            await cmd.ExecuteNonQueryAsync();
+        }
+
+        public async Task UpdateRuleExpressionAsync(int ruleId, string expression)
+        {
+            _logger.LogInformation(
+                "Updating rule {RuleId} expression to {Expression}.",
+                ruleId,
+                expression);
+
+            await using var conn = await _db.OpenConnectionAsync();
+            await using var cmd = _db.CreateCommand(conn, RulesSql.UpdateRuleExpression);
+            cmd.Parameters.Add(_db.CreateParameter("@RuleId", ruleId));
+            cmd.Parameters.Add(_db.CreateParameter("@Expression", expression ?? string.Empty));
+
+            await cmd.ExecuteNonQueryAsync();
         }
 
         public async Task<int> CreateRuleActionAsync(RuleActionCreateDto dto)

--- a/Repositories/Sql/RulesSql.cs
+++ b/Repositories/Sql/RulesSql.cs
@@ -38,6 +38,16 @@ namespace GMS.TifoXRCoreWebAPI.Repositories.Sql
             WHERE rcg.id = @Id
             LIMIT 1;";
 
+        public const string GetConditionContext = @"
+            SELECT rc.group_id AS GroupId,
+                   rcg.rule_id AS RuleId,
+                   r.space_id AS SpaceId
+            FROM rule_condition rc
+            JOIN rule_condition_group rcg ON rcg.id = rc.group_id
+            JOIN rules r ON r.id = rcg.rule_id
+            WHERE rc.id = @Id
+            LIMIT 1;";
+
         public const string GetStateTypeIdByName = @"
             SELECT id FROM state_type WHERE type = @Type LIMIT 1;";
 
@@ -138,6 +148,35 @@ namespace GMS.TifoXRCoreWebAPI.Repositories.Sql
             INSERT INTO rule_condition (group_id, parameter_id, comparator_id, negate, right_value_kind, right_value_json, order_index, creation_time, modified_by)
             VALUES (@GroupId, @ParameterId, @ComparatorId, @Negate, @RightValueKind, @RightValueJson, @OrderIndex, NOW(6), 'system');
             SELECT LAST_INSERT_ID();";
+
+        public const string UpdateConditionGroup = @"
+            UPDATE rule_condition_group
+            SET parent_group_id = @ParentGroupId,
+                re_logical_operator_id = @LogicalOperatorId,
+                order_index = @OrderIndex,
+                modified_time = NOW(6),
+                modified_by = 'system'
+            WHERE id = @Id;";
+
+        public const string UpdateCondition = @"
+            UPDATE rule_condition
+            SET group_id = @GroupId,
+                parameter_id = @ParameterId,
+                comparator_id = @ComparatorId,
+                negate = @Negate,
+                right_value_kind = @RightValueKind,
+                right_value_json = @RightValueJson,
+                order_index = @OrderIndex,
+                modified_time = NOW(6),
+                modified_by = 'system'
+            WHERE id = @Id;";
+
+        public const string UpdateRuleExpression = @"
+            UPDATE rules
+            SET expression = @Expression,
+                modified_time = NOW(6),
+                modified_by = 'system'
+            WHERE id = @RuleId;";
 
         public const string InsertRuleAction = @"
             INSERT INTO rule_actions (rule_id, action_type_id, action_name, action_key, action_parameters_json, action_target_ref, order_index, is_active, creation_time, modified_by)

--- a/Services/Interfaces/IRulesAuthoringService.cs
+++ b/Services/Interfaces/IRulesAuthoringService.cs
@@ -18,6 +18,8 @@ namespace GMS.TifoXRCoreWebAPI.Services
         Task<int> CreateRuleAsync(RuleCreateDto dto);
         Task<IReadOnlyList<int>> AddConditionGroupsAsync(int ruleId, IEnumerable<ConditionGroupCreateDto> groups);
         Task<IReadOnlyList<int>> AddConditionsAsync(int groupId, IEnumerable<ConditionCreateDto> conditions);
+        Task<RuleExpressionUpdateResult> UpdateConditionGroupAsync(ConditionGroupUpdateDto dto);
+        Task<RuleExpressionUpdateResult> UpdateConditionAsync(ConditionUpdateDto dto);
         Task<int> CreateRuleActionAsync(RuleActionCreateDto dto);
         Task BindRewardAsync(int actionId, int rewardId);
     }

--- a/Services/RulesAuthoringService.cs
+++ b/Services/RulesAuthoringService.cs
@@ -153,6 +153,66 @@ namespace GMS.TifoXRCoreWebAPI.Services
             return ids;
         }
 
+        public async Task<RuleExpressionUpdateResult> UpdateConditionGroupAsync(ConditionGroupUpdateDto dto)
+        {
+            if (dto is null) throw new ArgumentNullException(nameof(dto));
+
+            var (exists, ruleId, spaceId) = await _repo.TryGetConditionGroupContextAsync(dto.Id);
+            if (!exists)
+                throw new InvalidOperationException($"Condition group {dto.Id} does not exist.");
+
+            if (dto.RuleId != ruleId)
+                throw new InvalidOperationException(
+                    $"Condition group {dto.Id} belongs to rule {ruleId} and cannot be updated for rule {dto.RuleId}.");
+
+            if (dto.ParentGroupId.HasValue)
+            {
+                var belongs = await _repo.ConditionGroupBelongsToRuleAsync(dto.ParentGroupId.Value, ruleId);
+                if (!belongs)
+                    throw new InvalidOperationException(
+                        $"Parent condition group {dto.ParentGroupId.Value} does not belong to rule {ruleId}.");
+            }
+
+            await _repo.UpdateConditionGroupAsync(dto);
+
+            var expression = await RefreshRuleExpressionAsync(ruleId);
+            _evaluationService.Invalidate(spaceId);
+
+            return new RuleExpressionUpdateResult
+            {
+                RuleId = ruleId,
+                Expression = expression
+            };
+        }
+
+        public async Task<RuleExpressionUpdateResult> UpdateConditionAsync(ConditionUpdateDto dto)
+        {
+            if (dto is null) throw new ArgumentNullException(nameof(dto));
+
+            var (exists, currentGroupId, ruleId, spaceId) = await _repo.TryGetConditionContextAsync(dto.Id);
+            if (!exists)
+                throw new InvalidOperationException($"Condition {dto.Id} does not exist.");
+
+            if (dto.GroupId != currentGroupId)
+            {
+                var belongs = await _repo.ConditionGroupBelongsToRuleAsync(dto.GroupId, ruleId);
+                if (!belongs)
+                    throw new InvalidOperationException(
+                        $"Condition group {dto.GroupId} does not belong to rule {ruleId}.");
+            }
+
+            await _repo.UpdateConditionAsync(dto);
+
+            var expression = await RefreshRuleExpressionAsync(ruleId);
+            _evaluationService.Invalidate(spaceId);
+
+            return new RuleExpressionUpdateResult
+            {
+                RuleId = ruleId,
+                Expression = expression
+            };
+        }
+
         public async Task<int> CreateRuleActionAsync(RuleActionCreateDto dto)
         {
             if (dto is null) throw new ArgumentNullException(nameof(dto));
@@ -189,6 +249,15 @@ namespace GMS.TifoXRCoreWebAPI.Services
                 throw new InvalidOperationException($"State type '{DefaultStateTypeName}' is not configured.");
 
             return fallback.Value;
+        }
+
+        private async Task<string> RefreshRuleExpressionAsync(int ruleId)
+        {
+            var groups = await _repo.GetRuleConditionGroupsAsync(ruleId);
+            var conditions = await _repo.GetRuleConditionsAsync(ruleId);
+            var expression = ComposeExpression(groups, conditions);
+            await _repo.UpdateRuleExpressionAsync(ruleId, expression);
+            return expression;
         }
 
         private static string ComposeExpression(


### PR DESCRIPTION
## Summary
- add PUT endpoints for updating condition groups and individual conditions with route/body validation
- extend rules authoring services and repositories to persist updates and refresh rule expressions automatically
- add supporting SQL commands and DTOs for update flows

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dfdbe601a483299e1a794fd14d8269