### PR TITLE
Bind route identifiers into rules authoring payload DTOs

### DIFF
--- a/Controllers/RulesAuthoringController.cs
+++ b/Controllers/RulesAuthoringController.cs
@@ -24,7 +24,9 @@ namespace GMS.TifoXRCoreWebAPI.Controllers
 
         [HttpPost("workflows")]
         [ProducesResponseType(typeof(object), StatusCodes.Status201Created)]
-        public async Task<ActionResult<object>> CreateWorkflow([FromBody] WorkflowCreateDto dto)
+        public async Task<ActionResult<object>> CreateWorkflow(
+            int spaceId,
+            [FromBody] WorkflowCreateDto dto)
         {
             if (dto is null)
                 throw ErrorService.Exception(
@@ -33,12 +35,14 @@ namespace GMS.TifoXRCoreWebAPI.Controllers
                     ErrorMessages.Validation.MissingParameter,
                     paramName: nameof(dto));
 
-            if (dto.SpaceId <= 0)
+            if (spaceId <= 0)
                 throw ErrorService.Exception(
                     ErrorType.Argument,
                     nameof(CreateWorkflow),
                     ErrorMessages.Validation.PositiveIntRequired,
-                    paramName: nameof(dto.SpaceId));
+                    paramName: nameof(spaceId));
+
+            dto.SpaceId = spaceId;
 
             var id = await _svc.CreateWorkflowAsync(dto);
             return CreatedAtAction(nameof(CreateWorkflow), new { id }, new { id });
@@ -67,21 +71,8 @@ namespace GMS.TifoXRCoreWebAPI.Controllers
                     paramName: nameof(dto),
                     parameters: new { spaceId, ruleId });
 
-            if (dto.RuleId != ruleId)
-                throw ErrorService.Exception(
-                    ErrorType.Argument,
-                    nameof(UpdateRule),
-                    ErrorMessages.Validation.RouteBodyMismatch,
-                    paramName: nameof(dto.RuleId),
-                    parameters: new { expected = ruleId, actual = dto.RuleId });
-
-            if (dto.SpaceId != spaceId)
-                throw ErrorService.Exception(
-                    ErrorType.Argument,
-                    nameof(UpdateRule),
-                    ErrorMessages.Validation.RouteBodyMismatch,
-                    paramName: nameof(dto.SpaceId),
-                    parameters: new { expected = spaceId, actual = dto.SpaceId });
+            dto.RuleId = ruleId;
+            dto.SpaceId = spaceId;
 
             var result = await _svc.UpdateRuleDefinitionAsync(dto);
             return Ok(result);
@@ -89,7 +80,10 @@ namespace GMS.TifoXRCoreWebAPI.Controllers
 
         [HttpPost("workflows/{workflowId:int}/rules")]
         [ProducesResponseType(typeof(object), StatusCodes.Status201Created)]
-        public async Task<ActionResult<object>> CreateRule(int workflowId, [FromBody] RuleCreateDto dto)
+        public async Task<ActionResult<object>> CreateRule(
+            int spaceId,
+            int workflowId,
+            [FromBody] RuleCreateDto dto)
         {
             if (dto is null)
                 throw ErrorService.Exception(
@@ -99,21 +93,16 @@ namespace GMS.TifoXRCoreWebAPI.Controllers
                     paramName: nameof(dto),
                     parameters: new { workflowId });
 
-            if (dto.WorkflowId != workflowId)
-                throw ErrorService.Exception(
-                    ErrorType.Argument,
-                    nameof(CreateRule),
-                    ErrorMessages.Validation.RouteBodyMismatch,
-                    paramName: nameof(dto.WorkflowId),
-                    parameters: new { expected = workflowId, actual = dto.WorkflowId });
-
-            if (dto.SpaceId <= 0)
+            if (spaceId <= 0)
                 throw ErrorService.Exception(
                     ErrorType.Argument,
                     nameof(CreateRule),
                     ErrorMessages.Validation.PositiveIntRequired,
-                    paramName: nameof(dto.SpaceId),
+                    paramName: nameof(spaceId),
                     parameters: new { workflowId });
+
+            dto.WorkflowId = workflowId;
+            dto.SpaceId = spaceId;
 
             var id = await _svc.CreateRuleAsync(dto);
             return CreatedAtAction(nameof(CreateRule), new { workflowId, id }, new { id });
@@ -121,7 +110,10 @@ namespace GMS.TifoXRCoreWebAPI.Controllers
 
         [HttpPost("rules/{ruleId:int}/condition-groups")]
         [ProducesResponseType(typeof(object), StatusCodes.Status200OK)]
-        public async Task<ActionResult<object>> AddConditionGroups(int ruleId, [FromBody] IReadOnlyList<ConditionGroupCreateDto> dtos)
+        public async Task<ActionResult<object>> AddConditionGroups(
+            int spaceId,
+            int ruleId,
+            [FromBody] IReadOnlyList<ConditionGroupCreateDto> dtos)
         {
             if (dtos is null)
                 throw ErrorService.Exception(
@@ -131,13 +123,21 @@ namespace GMS.TifoXRCoreWebAPI.Controllers
                     paramName: nameof(dtos),
                     parameters: new { ruleId });
 
+            foreach (var dto in dtos)
+            {
+                dto.RuleId = ruleId;
+            }
+
             var ids = await _svc.AddConditionGroupsAsync(ruleId, dtos);
             return Ok(new { ids });
         }
 
         [HttpPost("condition-groups/{groupId:int}/conditions")]
         [ProducesResponseType(typeof(object), StatusCodes.Status200OK)]
-        public async Task<ActionResult<object>> AddConditions(int groupId, [FromBody] IReadOnlyList<ConditionCreateDto> dtos)
+        public async Task<ActionResult<object>> AddConditions(
+            int spaceId,
+            int groupId,
+            [FromBody] IReadOnlyList<ConditionCreateDto> dtos)
         {
             if (dtos is null)
                 throw ErrorService.Exception(
@@ -147,6 +147,11 @@ namespace GMS.TifoXRCoreWebAPI.Controllers
                     paramName: nameof(dtos),
                     parameters: new { groupId });
 
+            foreach (var dto in dtos)
+            {
+                dto.GroupId = groupId;
+            }
+
             var ids = await _svc.AddConditionsAsync(groupId, dtos);
             return Ok(new { ids });
         }
@@ -154,6 +159,7 @@ namespace GMS.TifoXRCoreWebAPI.Controllers
         [HttpPut("rules/{ruleId:int}/condition-groups/{groupId:int}")]
         [ProducesResponseType(typeof(RuleExpressionUpdateResult), StatusCodes.Status200OK)]
         public async Task<ActionResult<RuleExpressionUpdateResult>> UpdateConditionGroup(
+            int spaceId,
             int ruleId,
             int groupId,
             [FromBody] ConditionGroupUpdateDto dto)
@@ -166,21 +172,8 @@ namespace GMS.TifoXRCoreWebAPI.Controllers
                     paramName: nameof(dto),
                     parameters: new { ruleId, groupId });
 
-            if (dto.Id != groupId)
-                throw ErrorService.Exception(
-                    ErrorType.Argument,
-                    nameof(UpdateConditionGroup),
-                    ErrorMessages.Validation.RouteBodyMismatch,
-                    paramName: nameof(dto.Id),
-                    parameters: new { expected = groupId, actual = dto.Id });
-
-            if (dto.RuleId != ruleId)
-                throw ErrorService.Exception(
-                    ErrorType.Argument,
-                    nameof(UpdateConditionGroup),
-                    ErrorMessages.Validation.RouteBodyMismatch,
-                    paramName: nameof(dto.RuleId),
-                    parameters: new { expected = ruleId, actual = dto.RuleId });
+            dto.Id = groupId;
+            dto.RuleId = ruleId;
 
             var result = await _svc.UpdateConditionGroupAsync(dto);
             return Ok(result);
@@ -189,6 +182,7 @@ namespace GMS.TifoXRCoreWebAPI.Controllers
         [HttpPut("condition-groups/{groupId:int}/conditions/{conditionId:int}")]
         [ProducesResponseType(typeof(RuleExpressionUpdateResult), StatusCodes.Status200OK)]
         public async Task<ActionResult<RuleExpressionUpdateResult>> UpdateCondition(
+            int spaceId,
             int groupId,
             int conditionId,
             [FromBody] ConditionUpdateDto dto)
@@ -201,21 +195,8 @@ namespace GMS.TifoXRCoreWebAPI.Controllers
                     paramName: nameof(dto),
                     parameters: new { groupId, conditionId });
 
-            if (dto.Id != conditionId)
-                throw ErrorService.Exception(
-                    ErrorType.Argument,
-                    nameof(UpdateCondition),
-                    ErrorMessages.Validation.RouteBodyMismatch,
-                    paramName: nameof(dto.Id),
-                    parameters: new { expected = conditionId, actual = dto.Id });
-
-            if (dto.GroupId != groupId)
-                throw ErrorService.Exception(
-                    ErrorType.Argument,
-                    nameof(UpdateCondition),
-                    ErrorMessages.Validation.RouteBodyMismatch,
-                    paramName: nameof(dto.GroupId),
-                    parameters: new { expected = groupId, actual = dto.GroupId });
+            dto.Id = conditionId;
+            dto.GroupId = groupId;
 
             var result = await _svc.UpdateConditionAsync(dto);
             return Ok(result);
@@ -223,7 +204,10 @@ namespace GMS.TifoXRCoreWebAPI.Controllers
 
         [HttpPost("rules/{ruleId:int}/actions")]
         [ProducesResponseType(typeof(object), StatusCodes.Status201Created)]
-        public async Task<ActionResult<object>> CreateRuleAction(int ruleId, [FromBody] RuleActionCreateDto dto)
+        public async Task<ActionResult<object>> CreateRuleAction(
+            int spaceId,
+            int ruleId,
+            [FromBody] RuleActionCreateDto dto)
         {
             if (dto is null)
                 throw ErrorService.Exception(
@@ -233,13 +217,7 @@ namespace GMS.TifoXRCoreWebAPI.Controllers
                     paramName: nameof(dto),
                     parameters: new { ruleId });
 
-            if (dto.RuleId != ruleId)
-                throw ErrorService.Exception(
-                    ErrorType.Argument,
-                    nameof(CreateRuleAction),
-                    ErrorMessages.Validation.RouteBodyMismatch,
-                    paramName: nameof(dto.RuleId),
-                    parameters: new { expected = ruleId, actual = dto.RuleId });
+            dto.RuleId = ruleId;
 
             var id = await _svc.CreateRuleActionAsync(dto);
             return CreatedAtAction(nameof(CreateRuleAction), new { ruleId, id }, new { id });
@@ -247,7 +225,10 @@ namespace GMS.TifoXRCoreWebAPI.Controllers
 
         [HttpPost("rule-actions/{actionId:int}/reward")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
-        public async Task<IActionResult> BindRewardToAction(int actionId, [FromBody] RuleActionRewardBindDto dto)
+        public async Task<IActionResult> BindRewardToAction(
+            int spaceId,
+            int actionId,
+            [FromBody] RuleActionRewardBindDto dto)
         {
             if (dto is null)
                 throw ErrorService.Exception(
@@ -255,7 +236,7 @@ namespace GMS.TifoXRCoreWebAPI.Controllers
                     nameof(BindRewardToAction),
                     ErrorMessages.Validation.MissingParameter,
                     paramName: nameof(dto),
-                    parameters: new { actionId });
+                    parameters: new { spaceId, actionId });
 
             if (dto.RewardId <= 0)
                 throw ErrorService.Exception(
@@ -263,7 +244,7 @@ namespace GMS.TifoXRCoreWebAPI.Controllers
                     nameof(BindRewardToAction),
                     ErrorMessages.Validation.PositiveIntRequired,
                     paramName: nameof(dto.RewardId),
-                    parameters: new { actionId, dto.RewardId });
+                    parameters: new { spaceId, actionId, dto.RewardId });
 
             await _svc.BindRewardAsync(actionId, dto.RewardId);
             return NoContent();

--- a/Models/RulesModels.cs
+++ b/Models/RulesModels.cs
@@ -47,7 +47,7 @@ namespace GMS.TifoXRCoreWebAPI.Models
 
     public sealed class WorkflowCreateDto
     {
-        public int SpaceId { get; init; }
+        public int SpaceId { get; set; }
         public string Name { get; init; } = default!;
         public int? StateTypeId { get; init; }
     }
@@ -62,8 +62,8 @@ namespace GMS.TifoXRCoreWebAPI.Models
 
     public sealed class RuleCreateDto
     {
-        public int WorkflowId { get; init; }
-        public int SpaceId { get; init; }
+        public int WorkflowId { get; set; }
+        public int SpaceId { get; set; }
         public string RuleName { get; init; } = default!;
         public string? Expression { get; init; }
         public string? TargetType { get; init; }
@@ -202,7 +202,7 @@ namespace GMS.TifoXRCoreWebAPI.Models
 
     public class ConditionGroupCreateDto
     {
-        public int RuleId { get; init; }
+        public int RuleId { get; set; }
         public int? ParentGroupId { get; init; }
         public int LogicalOperatorId { get; init; }
         public int OrderIndex { get; init; } = 1;
@@ -212,7 +212,7 @@ namespace GMS.TifoXRCoreWebAPI.Models
 
     public sealed class ConditionGroupUpdateDto : ConditionGroupCreateDto
     {
-        public int Id { get; init; }
+        public int Id { get; set; }
     }
 
     public class ConditionGroupView
@@ -232,7 +232,7 @@ namespace GMS.TifoXRCoreWebAPI.Models
 
     public class ConditionCreateDto
     {
-        public int GroupId { get; init; }
+        public int GroupId { get; set; }
         public int ParameterId { get; init; }
         public int ComparatorId { get; init; }
         public bool Negate { get; init; } = false;
@@ -243,7 +243,7 @@ namespace GMS.TifoXRCoreWebAPI.Models
 
     public sealed class ConditionUpdateDto : ConditionCreateDto
     {
-        public int Id { get; init; }
+        public int Id { get; set; }
     }
 
     public class ConditionView
@@ -269,8 +269,8 @@ namespace GMS.TifoXRCoreWebAPI.Models
 
     public sealed class RuleDefinitionUpdateDto
     {
-        public int RuleId { get; init; }
-        public int SpaceId { get; init; }
+        public int RuleId { get; set; }
+        public int SpaceId { get; set; }
         public string RuleName { get; init; } = default!;
         public string? TargetType { get; init; }
         public string? SuccessEvent { get; init; }
@@ -301,7 +301,7 @@ namespace GMS.TifoXRCoreWebAPI.Models
 
     public sealed class RuleActionCreateDto
     {
-        public int RuleId { get; init; }
+        public int RuleId { get; set; }
         public int ActionTypeId { get; init; }
         public string ActionName { get; init; } = default!;
         public string ActionKey { get; init; } = default!;


### PR DESCRIPTION
## Summary
- bind route identifiers onto rules authoring DTO payloads within the controller so requests no longer need to send redundant IDs
- update the rules authoring DTO models to allow controller-assigned identifiers and remove the temporary request payload types

## Testing
- not run (dotnet CLI not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68dfe5bb16348329a1d8b322b3bd1654