### PR TITLE
Stop requiring redundant IDs in rules authoring payloads

### DIFF
--- a/Controllers/RulesAuthoringController.cs
+++ b/Controllers/RulesAuthoringController.cs
@@ -24,7 +24,9 @@ namespace GMS.TifoXRCoreWebAPI.Controllers
 
         [HttpPost("workflows")]
         [ProducesResponseType(typeof(object), StatusCodes.Status201Created)]
-        public async Task<ActionResult<object>> CreateWorkflow([FromBody] WorkflowCreateDto dto)
+        public async Task<ActionResult<object>> CreateWorkflow(
+            int spaceId,
+            [FromBody] WorkflowCreateDto dto)
         {
             if (dto is null)
                 throw ErrorService.Exception(
@@ -33,14 +35,14 @@ namespace GMS.TifoXRCoreWebAPI.Controllers
                     ErrorMessages.Validation.MissingParameter,
                     paramName: nameof(dto));
 
-            if (dto.SpaceId <= 0)
+            if (spaceId <= 0)
                 throw ErrorService.Exception(
                     ErrorType.Argument,
                     nameof(CreateWorkflow),
                     ErrorMessages.Validation.PositiveIntRequired,
-                    paramName: nameof(dto.SpaceId));
+                    paramName: nameof(spaceId));
 
-            var id = await _svc.CreateWorkflowAsync(dto);
+            var id = await _svc.CreateWorkflowAsync(spaceId, dto);
             return CreatedAtAction(nameof(CreateWorkflow), new { id }, new { id });
         }
 
@@ -67,29 +69,16 @@ namespace GMS.TifoXRCoreWebAPI.Controllers
                     paramName: nameof(dto),
                     parameters: new { spaceId, ruleId });
 
-            if (dto.RuleId != ruleId)
-                throw ErrorService.Exception(
-                    ErrorType.Argument,
-                    nameof(UpdateRule),
-                    ErrorMessages.Validation.RouteBodyMismatch,
-                    paramName: nameof(dto.RuleId),
-                    parameters: new { expected = ruleId, actual = dto.RuleId });
-
-            if (dto.SpaceId != spaceId)
-                throw ErrorService.Exception(
-                    ErrorType.Argument,
-                    nameof(UpdateRule),
-                    ErrorMessages.Validation.RouteBodyMismatch,
-                    paramName: nameof(dto.SpaceId),
-                    parameters: new { expected = spaceId, actual = dto.SpaceId });
-
-            var result = await _svc.UpdateRuleDefinitionAsync(dto);
+            var result = await _svc.UpdateRuleDefinitionAsync(spaceId, ruleId, dto);
             return Ok(result);
         }
 
         [HttpPost("workflows/{workflowId:int}/rules")]
         [ProducesResponseType(typeof(object), StatusCodes.Status201Created)]
-        public async Task<ActionResult<object>> CreateRule(int workflowId, [FromBody] RuleCreateDto dto)
+        public async Task<ActionResult<object>> CreateRule(
+            int spaceId,
+            int workflowId,
+            [FromBody] RuleCreateDto dto)
         {
             if (dto is null)
                 throw ErrorService.Exception(
@@ -99,29 +88,24 @@ namespace GMS.TifoXRCoreWebAPI.Controllers
                     paramName: nameof(dto),
                     parameters: new { workflowId });
 
-            if (dto.WorkflowId != workflowId)
-                throw ErrorService.Exception(
-                    ErrorType.Argument,
-                    nameof(CreateRule),
-                    ErrorMessages.Validation.RouteBodyMismatch,
-                    paramName: nameof(dto.WorkflowId),
-                    parameters: new { expected = workflowId, actual = dto.WorkflowId });
-
-            if (dto.SpaceId <= 0)
+            if (spaceId <= 0)
                 throw ErrorService.Exception(
                     ErrorType.Argument,
                     nameof(CreateRule),
                     ErrorMessages.Validation.PositiveIntRequired,
-                    paramName: nameof(dto.SpaceId),
+                    paramName: nameof(spaceId),
                     parameters: new { workflowId });
 
-            var id = await _svc.CreateRuleAsync(dto);
+            var id = await _svc.CreateRuleAsync(spaceId, workflowId, dto);
             return CreatedAtAction(nameof(CreateRule), new { workflowId, id }, new { id });
         }
 
         [HttpPost("rules/{ruleId:int}/condition-groups")]
         [ProducesResponseType(typeof(object), StatusCodes.Status200OK)]
-        public async Task<ActionResult<object>> AddConditionGroups(int ruleId, [FromBody] IReadOnlyList<ConditionGroupCreateDto> dtos)
+        public async Task<ActionResult<object>> AddConditionGroups(
+            int spaceId,
+            int ruleId,
+            [FromBody] IReadOnlyList<ConditionGroupCreateDto> dtos)
         {
             if (dtos is null)
                 throw ErrorService.Exception(
@@ -137,7 +121,10 @@ namespace GMS.TifoXRCoreWebAPI.Controllers
 
         [HttpPost("condition-groups/{groupId:int}/conditions")]
         [ProducesResponseType(typeof(object), StatusCodes.Status200OK)]
-        public async Task<ActionResult<object>> AddConditions(int groupId, [FromBody] IReadOnlyList<ConditionCreateDto> dtos)
+        public async Task<ActionResult<object>> AddConditions(
+            int spaceId,
+            int groupId,
+            [FromBody] IReadOnlyList<ConditionCreateDto> dtos)
         {
             if (dtos is null)
                 throw ErrorService.Exception(
@@ -154,6 +141,7 @@ namespace GMS.TifoXRCoreWebAPI.Controllers
         [HttpPut("rules/{ruleId:int}/condition-groups/{groupId:int}")]
         [ProducesResponseType(typeof(RuleExpressionUpdateResult), StatusCodes.Status200OK)]
         public async Task<ActionResult<RuleExpressionUpdateResult>> UpdateConditionGroup(
+            int spaceId,
             int ruleId,
             int groupId,
             [FromBody] ConditionGroupUpdateDto dto)
@@ -166,29 +154,14 @@ namespace GMS.TifoXRCoreWebAPI.Controllers
                     paramName: nameof(dto),
                     parameters: new { ruleId, groupId });
 
-            if (dto.Id != groupId)
-                throw ErrorService.Exception(
-                    ErrorType.Argument,
-                    nameof(UpdateConditionGroup),
-                    ErrorMessages.Validation.RouteBodyMismatch,
-                    paramName: nameof(dto.Id),
-                    parameters: new { expected = groupId, actual = dto.Id });
-
-            if (dto.RuleId != ruleId)
-                throw ErrorService.Exception(
-                    ErrorType.Argument,
-                    nameof(UpdateConditionGroup),
-                    ErrorMessages.Validation.RouteBodyMismatch,
-                    paramName: nameof(dto.RuleId),
-                    parameters: new { expected = ruleId, actual = dto.RuleId });
-
-            var result = await _svc.UpdateConditionGroupAsync(dto);
+            var result = await _svc.UpdateConditionGroupAsync(ruleId, groupId, dto);
             return Ok(result);
         }
 
         [HttpPut("condition-groups/{groupId:int}/conditions/{conditionId:int}")]
         [ProducesResponseType(typeof(RuleExpressionUpdateResult), StatusCodes.Status200OK)]
         public async Task<ActionResult<RuleExpressionUpdateResult>> UpdateCondition(
+            int spaceId,
             int groupId,
             int conditionId,
             [FromBody] ConditionUpdateDto dto)
@@ -201,29 +174,16 @@ namespace GMS.TifoXRCoreWebAPI.Controllers
                     paramName: nameof(dto),
                     parameters: new { groupId, conditionId });
 
-            if (dto.Id != conditionId)
-                throw ErrorService.Exception(
-                    ErrorType.Argument,
-                    nameof(UpdateCondition),
-                    ErrorMessages.Validation.RouteBodyMismatch,
-                    paramName: nameof(dto.Id),
-                    parameters: new { expected = conditionId, actual = dto.Id });
-
-            if (dto.GroupId != groupId)
-                throw ErrorService.Exception(
-                    ErrorType.Argument,
-                    nameof(UpdateCondition),
-                    ErrorMessages.Validation.RouteBodyMismatch,
-                    paramName: nameof(dto.GroupId),
-                    parameters: new { expected = groupId, actual = dto.GroupId });
-
-            var result = await _svc.UpdateConditionAsync(dto);
+            var result = await _svc.UpdateConditionAsync(groupId, conditionId, dto);
             return Ok(result);
         }
 
         [HttpPost("rules/{ruleId:int}/actions")]
         [ProducesResponseType(typeof(object), StatusCodes.Status201Created)]
-        public async Task<ActionResult<object>> CreateRuleAction(int ruleId, [FromBody] RuleActionCreateDto dto)
+        public async Task<ActionResult<object>> CreateRuleAction(
+            int spaceId,
+            int ruleId,
+            [FromBody] RuleActionCreateDto dto)
         {
             if (dto is null)
                 throw ErrorService.Exception(
@@ -233,21 +193,16 @@ namespace GMS.TifoXRCoreWebAPI.Controllers
                     paramName: nameof(dto),
                     parameters: new { ruleId });
 
-            if (dto.RuleId != ruleId)
-                throw ErrorService.Exception(
-                    ErrorType.Argument,
-                    nameof(CreateRuleAction),
-                    ErrorMessages.Validation.RouteBodyMismatch,
-                    paramName: nameof(dto.RuleId),
-                    parameters: new { expected = ruleId, actual = dto.RuleId });
-
-            var id = await _svc.CreateRuleActionAsync(dto);
+            var id = await _svc.CreateRuleActionAsync(ruleId, dto);
             return CreatedAtAction(nameof(CreateRuleAction), new { ruleId, id }, new { id });
         }
 
         [HttpPost("rule-actions/{actionId:int}/reward")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
-        public async Task<IActionResult> BindRewardToAction(int actionId, [FromBody] RuleActionRewardBindDto dto)
+        public async Task<IActionResult> BindRewardToAction(
+            int spaceId,
+            int actionId,
+            [FromBody] RuleActionRewardBindDto dto)
         {
             if (dto is null)
                 throw ErrorService.Exception(
@@ -255,7 +210,7 @@ namespace GMS.TifoXRCoreWebAPI.Controllers
                     nameof(BindRewardToAction),
                     ErrorMessages.Validation.MissingParameter,
                     paramName: nameof(dto),
-                    parameters: new { actionId });
+                    parameters: new { spaceId, actionId });
 
             if (dto.RewardId <= 0)
                 throw ErrorService.Exception(
@@ -263,7 +218,7 @@ namespace GMS.TifoXRCoreWebAPI.Controllers
                     nameof(BindRewardToAction),
                     ErrorMessages.Validation.PositiveIntRequired,
                     paramName: nameof(dto.RewardId),
-                    parameters: new { actionId, dto.RewardId });
+                    parameters: new { spaceId, actionId, dto.RewardId });
 
             await _svc.BindRewardAsync(actionId, dto.RewardId);
             return NoContent();

--- a/Models/RulesModels.cs
+++ b/Models/RulesModels.cs
@@ -47,7 +47,6 @@ namespace GMS.TifoXRCoreWebAPI.Models
 
     public sealed class WorkflowCreateDto
     {
-        public int SpaceId { get; init; }
         public string Name { get; init; } = default!;
         public int? StateTypeId { get; init; }
     }
@@ -62,8 +61,6 @@ namespace GMS.TifoXRCoreWebAPI.Models
 
     public sealed class RuleCreateDto
     {
-        public int WorkflowId { get; init; }
-        public int SpaceId { get; init; }
         public string RuleName { get; init; } = default!;
         public string? Expression { get; init; }
         public string? TargetType { get; init; }
@@ -202,7 +199,6 @@ namespace GMS.TifoXRCoreWebAPI.Models
 
     public class ConditionGroupCreateDto
     {
-        public int RuleId { get; init; }
         public int? ParentGroupId { get; init; }
         public int LogicalOperatorId { get; init; }
         public int OrderIndex { get; init; } = 1;
@@ -210,9 +206,13 @@ namespace GMS.TifoXRCoreWebAPI.Models
         public string? DescriptionKey { get; init; }
     }
 
-    public sealed class ConditionGroupUpdateDto : ConditionGroupCreateDto
+    public sealed class ConditionGroupUpdateDto
     {
-        public int Id { get; init; }
+        public int? ParentGroupId { get; init; }
+        public int LogicalOperatorId { get; init; }
+        public int OrderIndex { get; init; } = 1;
+        public string? NameKey { get; init; }
+        public string? DescriptionKey { get; init; }
     }
 
     public class ConditionGroupView
@@ -232,7 +232,6 @@ namespace GMS.TifoXRCoreWebAPI.Models
 
     public class ConditionCreateDto
     {
-        public int GroupId { get; init; }
         public int ParameterId { get; init; }
         public int ComparatorId { get; init; }
         public bool Negate { get; init; } = false;
@@ -241,9 +240,14 @@ namespace GMS.TifoXRCoreWebAPI.Models
         public int OrderIndex { get; init; } = 1;
     }
 
-    public sealed class ConditionUpdateDto : ConditionCreateDto
+    public sealed class ConditionUpdateDto
     {
-        public int Id { get; init; }
+        public int ParameterId { get; init; }
+        public int ComparatorId { get; init; }
+        public bool Negate { get; init; } = false;
+        public string RightValueKind { get; init; } = RightValueKinds.Literal;
+        public string? RightValueJson { get; init; }
+        public int OrderIndex { get; init; } = 1;
     }
 
     public class ConditionView
@@ -269,8 +273,6 @@ namespace GMS.TifoXRCoreWebAPI.Models
 
     public sealed class RuleDefinitionUpdateDto
     {
-        public int RuleId { get; init; }
-        public int SpaceId { get; init; }
         public string RuleName { get; init; } = default!;
         public string? TargetType { get; init; }
         public string? SuccessEvent { get; init; }
@@ -301,7 +303,6 @@ namespace GMS.TifoXRCoreWebAPI.Models
 
     public sealed class RuleActionCreateDto
     {
-        public int RuleId { get; init; }
         public int ActionTypeId { get; init; }
         public string ActionName { get; init; } = default!;
         public string ActionKey { get; init; } = default!;

--- a/Repositories/Interfaces/IRulesRepository.cs
+++ b/Repositories/Interfaces/IRulesRepository.cs
@@ -25,16 +25,16 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
         Task<IReadOnlyList<ConditionGroupDetailView>> GetRuleConditionGroupsAsync(int ruleId);
         Task<IReadOnlyList<ConditionDetailView>> GetRuleConditionsAsync(int ruleId);
 
-        Task UpdateRuleDefinitionAsync(RuleDefinitionUpdateDto dto, string expression);
+        Task UpdateRuleDefinitionAsync(int ruleId, RuleDefinitionUpdateDto dto, string expression);
 
-        Task<int> CreateWorkflowAsync(WorkflowCreateDto dto, int stateTypeId);
-        Task<int> CreateRuleAsync(RuleCreateDto dto, int stateTypeId);
-        Task<IReadOnlyList<int>> InsertConditionGroupsAsync(IEnumerable<ConditionGroupCreateDto> dtos);
-        Task<IReadOnlyList<int>> InsertConditionsAsync(IEnumerable<ConditionCreateDto> dtos);
-        Task UpdateConditionGroupAsync(ConditionGroupUpdateDto dto);
-        Task UpdateConditionAsync(ConditionUpdateDto dto);
+        Task<int> CreateWorkflowAsync(int spaceId, WorkflowCreateDto dto, int stateTypeId);
+        Task<int> CreateRuleAsync(int spaceId, int workflowId, RuleCreateDto dto, int stateTypeId);
+        Task<IReadOnlyList<int>> InsertConditionGroupsAsync(int ruleId, IEnumerable<ConditionGroupCreateDto> dtos);
+        Task<IReadOnlyList<int>> InsertConditionsAsync(int groupId, IEnumerable<ConditionCreateDto> dtos);
+        Task UpdateConditionGroupAsync(int groupId, ConditionGroupUpdateDto dto);
+        Task UpdateConditionAsync(int conditionId, int groupId, ConditionUpdateDto dto);
         Task UpdateRuleExpressionAsync(int ruleId, string expression);
-        Task<int> CreateRuleActionAsync(RuleActionCreateDto dto);
+        Task<int> CreateRuleActionAsync(int ruleId, RuleActionCreateDto dto);
         Task BindRewardToActionAsync(int actionId, int rewardId);
 
         Task<IReadOnlyList<RuntimeWorkflowDefinition>> GetRuntimeWorkflowsAsync(int spaceId);

--- a/Repositories/RulesRepository.cs
+++ b/Repositories/RulesRepository.cs
@@ -322,19 +322,19 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
             return list;
         }
 
-        public async Task UpdateRuleDefinitionAsync(RuleDefinitionUpdateDto dto, string expression)
+        public async Task UpdateRuleDefinitionAsync(int ruleId, RuleDefinitionUpdateDto dto, string expression)
         {
             if (dto is null) throw new ArgumentNullException(nameof(dto));
 
             _logger.LogInformation(
                 "Updating rule {RuleId} definition with payload {Payload} and expression {Expression}.",
-                dto.RuleId,
+                ruleId,
                 Serialize(dto),
                 expression);
 
             await using var conn = await _db.OpenConnectionAsync();
             await using var cmd = _db.CreateCommand(conn, RulesSql.UpdateRuleDefinition);
-            cmd.Parameters.Add(_db.CreateParameter("@RuleId", dto.RuleId));
+            cmd.Parameters.Add(_db.CreateParameter("@RuleId", ruleId));
             cmd.Parameters.Add(_db.CreateParameter("@RuleName", dto.RuleName));
             cmd.Parameters.Add(_db.CreateParameter("@TargetType", (object?)dto.TargetType ?? DBNull.Value));
             cmd.Parameters.Add(_db.CreateParameter("@SuccessEvent", (object?)dto.SuccessEvent ?? DBNull.Value));
@@ -345,18 +345,19 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
             await cmd.ExecuteNonQueryAsync();
         }
 
-        public async Task<int> CreateWorkflowAsync(WorkflowCreateDto dto, int stateTypeId)
+        public async Task<int> CreateWorkflowAsync(int spaceId, WorkflowCreateDto dto, int stateTypeId)
         {
             if (dto is null) throw new ArgumentNullException(nameof(dto));
 
             _logger.LogInformation(
-                "Creating workflow with payload {Payload} and state type {StateTypeId}.",
+                "Creating workflow in space {SpaceId} with payload {Payload} and state type {StateTypeId}.",
+                spaceId,
                 Serialize(dto),
                 stateTypeId);
             await using var conn = await _db.OpenConnectionAsync();
             await using var cmd = _db.CreateCommand(conn, RulesSql.InsertWorkflow);
 
-            cmd.Parameters.Add(_db.CreateParameter("@SpaceId", dto.SpaceId));
+            cmd.Parameters.Add(_db.CreateParameter("@SpaceId", spaceId));
             cmd.Parameters.Add(_db.CreateParameter("@Name", dto.Name));
             cmd.Parameters.Add(_db.CreateParameter("@StateTypeId", stateTypeId));
 
@@ -365,23 +366,25 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
             _logger.LogInformation(
                 "Workflow created with id {WorkflowId} for space {SpaceId}.",
                 workflowId,
-                dto.SpaceId);
+                spaceId);
             return workflowId;
         }
 
-        public async Task<int> CreateRuleAsync(RuleCreateDto dto, int stateTypeId)
+        public async Task<int> CreateRuleAsync(int spaceId, int workflowId, RuleCreateDto dto, int stateTypeId)
         {
             if (dto is null) throw new ArgumentNullException(nameof(dto));
 
             _logger.LogInformation(
-                "Creating rule with payload {Payload} and state type {StateTypeId}.",
+                "Creating rule for workflow {WorkflowId} in space {SpaceId} with payload {Payload} and state type {StateTypeId}.",
+                workflowId,
+                spaceId,
                 Serialize(dto),
                 stateTypeId);
             await using var conn = await _db.OpenConnectionAsync();
             await using var cmd = _db.CreateCommand(conn, RulesSql.InsertRule);
 
-            cmd.Parameters.Add(_db.CreateParameter("@WorkflowId", dto.WorkflowId));
-            cmd.Parameters.Add(_db.CreateParameter("@SpaceId", dto.SpaceId));
+            cmd.Parameters.Add(_db.CreateParameter("@WorkflowId", workflowId));
+            cmd.Parameters.Add(_db.CreateParameter("@SpaceId", spaceId));
             cmd.Parameters.Add(_db.CreateParameter("@RuleName", dto.RuleName));
             cmd.Parameters.Add(_db.CreateParameter("@Expression", dto.Expression ?? string.Empty));
             cmd.Parameters.Add(_db.CreateParameter("@TargetType", (object?)dto.TargetType ?? DBNull.Value));
@@ -397,19 +400,20 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
             _logger.LogInformation(
                 "Rule created with id {RuleId} for workflow {WorkflowId} in space {SpaceId}.",
                 ruleId,
-                dto.WorkflowId,
-                dto.SpaceId);
+                workflowId,
+                spaceId);
             return ruleId;
         }
 
-        public async Task<IReadOnlyList<int>> InsertConditionGroupsAsync(IEnumerable<ConditionGroupCreateDto> dtos)
+        public async Task<IReadOnlyList<int>> InsertConditionGroupsAsync(int ruleId, IEnumerable<ConditionGroupCreateDto> dtos)
         {
             if (dtos is null) throw new ArgumentNullException(nameof(dtos));
 
             var dtoList = dtos.ToList();
             _logger.LogInformation(
-                "Inserting {Count} condition groups with payload {Payload}.",
+                "Inserting {Count} condition groups for rule {RuleId} with payload {Payload}.",
                 dtoList.Count,
+                ruleId,
                 Serialize(dtoList));
             await using var conn = await _db.OpenConnectionAsync();
             await using var tx = await conn.BeginTransactionAsync();
@@ -420,7 +424,7 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
                 foreach (var dto in dtoList)
                 {
                     await using var cmd = _db.CreateCommand(conn, RulesSql.InsertConditionGroup, tx);
-                    cmd.Parameters.Add(_db.CreateParameter("@RuleId", dto.RuleId));
+                    cmd.Parameters.Add(_db.CreateParameter("@RuleId", ruleId));
                     cmd.Parameters.Add(_db.CreateParameter("@ParentGroupId", (object?)dto.ParentGroupId ?? DBNull.Value));
                     cmd.Parameters.Add(_db.CreateParameter("@LogicalOperatorId", dto.LogicalOperatorId));
                     cmd.Parameters.Add(_db.CreateParameter("@OrderIndex", dto.OrderIndex));
@@ -438,20 +442,22 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
             }
 
             _logger.LogInformation(
-                "Inserted condition groups with ids {Ids} for payload {Payload}.",
+                "Inserted condition groups with ids {Ids} for rule {RuleId} and payload {Payload}.",
                 Serialize(ids),
+                ruleId,
                 Serialize(dtoList));
             return ids;
         }
 
-        public async Task<IReadOnlyList<int>> InsertConditionsAsync(IEnumerable<ConditionCreateDto> dtos)
+        public async Task<IReadOnlyList<int>> InsertConditionsAsync(int groupId, IEnumerable<ConditionCreateDto> dtos)
         {
             if (dtos is null) throw new ArgumentNullException(nameof(dtos));
 
             var dtoList = dtos.ToList();
             _logger.LogInformation(
-                "Inserting {Count} conditions with payload {Payload}.",
+                "Inserting {Count} conditions for group {GroupId} with payload {Payload}.",
                 dtoList.Count,
+                groupId,
                 Serialize(dtoList));
             await using var conn = await _db.OpenConnectionAsync();
             await using var tx = await conn.BeginTransactionAsync();
@@ -462,7 +468,7 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
                 foreach (var dto in dtoList)
                 {
                     await using var cmd = _db.CreateCommand(conn, RulesSql.InsertCondition, tx);
-                    cmd.Parameters.Add(_db.CreateParameter("@GroupId", dto.GroupId));
+                    cmd.Parameters.Add(_db.CreateParameter("@GroupId", groupId));
                     cmd.Parameters.Add(_db.CreateParameter("@ParameterId", dto.ParameterId));
                     cmd.Parameters.Add(_db.CreateParameter("@ComparatorId", dto.ComparatorId));
                     cmd.Parameters.Add(_db.CreateParameter("@Negate", dto.Negate ? 1 : 0));
@@ -483,24 +489,25 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
             }
 
             _logger.LogInformation(
-                "Inserted conditions with ids {Ids} for payload {Payload}.",
+                "Inserted conditions with ids {Ids} for group {GroupId} and payload {Payload}.",
                 Serialize(ids),
+                groupId,
                 Serialize(dtoList));
             return ids;
         }
 
-        public async Task UpdateConditionGroupAsync(ConditionGroupUpdateDto dto)
+        public async Task UpdateConditionGroupAsync(int groupId, ConditionGroupUpdateDto dto)
         {
             if (dto is null) throw new ArgumentNullException(nameof(dto));
 
             _logger.LogInformation(
                 "Updating condition group {GroupId} with payload {Payload}.",
-                dto.Id,
+                groupId,
                 Serialize(dto));
 
             await using var conn = await _db.OpenConnectionAsync();
             await using var cmd = _db.CreateCommand(conn, RulesSql.UpdateConditionGroup);
-            cmd.Parameters.Add(_db.CreateParameter("@Id", dto.Id));
+            cmd.Parameters.Add(_db.CreateParameter("@Id", groupId));
             cmd.Parameters.Add(_db.CreateParameter("@ParentGroupId", (object?)dto.ParentGroupId ?? DBNull.Value));
             cmd.Parameters.Add(_db.CreateParameter("@LogicalOperatorId", dto.LogicalOperatorId));
             cmd.Parameters.Add(_db.CreateParameter("@OrderIndex", dto.OrderIndex));
@@ -508,19 +515,19 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
             await cmd.ExecuteNonQueryAsync();
         }
 
-        public async Task UpdateConditionAsync(ConditionUpdateDto dto)
+        public async Task UpdateConditionAsync(int conditionId, int groupId, ConditionUpdateDto dto)
         {
             if (dto is null) throw new ArgumentNullException(nameof(dto));
 
             _logger.LogInformation(
                 "Updating condition {ConditionId} with payload {Payload}.",
-                dto.Id,
+                conditionId,
                 Serialize(dto));
 
             await using var conn = await _db.OpenConnectionAsync();
             await using var cmd = _db.CreateCommand(conn, RulesSql.UpdateCondition);
-            cmd.Parameters.Add(_db.CreateParameter("@Id", dto.Id));
-            cmd.Parameters.Add(_db.CreateParameter("@GroupId", dto.GroupId));
+            cmd.Parameters.Add(_db.CreateParameter("@Id", conditionId));
+            cmd.Parameters.Add(_db.CreateParameter("@GroupId", groupId));
             cmd.Parameters.Add(_db.CreateParameter("@ParameterId", dto.ParameterId));
             cmd.Parameters.Add(_db.CreateParameter("@ComparatorId", dto.ComparatorId));
             cmd.Parameters.Add(_db.CreateParameter("@Negate", dto.Negate ? 1 : 0));
@@ -546,17 +553,18 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
             await cmd.ExecuteNonQueryAsync();
         }
 
-        public async Task<int> CreateRuleActionAsync(RuleActionCreateDto dto)
+        public async Task<int> CreateRuleActionAsync(int ruleId, RuleActionCreateDto dto)
         {
             if (dto is null) throw new ArgumentNullException(nameof(dto));
 
             _logger.LogInformation(
-                "Creating rule action with payload {Payload}.",
+                "Creating rule action for rule {RuleId} with payload {Payload}.",
+                ruleId,
                 Serialize(dto));
             await using var conn = await _db.OpenConnectionAsync();
             await using var cmd = _db.CreateCommand(conn, RulesSql.InsertRuleAction);
 
-            cmd.Parameters.Add(_db.CreateParameter("@RuleId", dto.RuleId));
+            cmd.Parameters.Add(_db.CreateParameter("@RuleId", ruleId));
             cmd.Parameters.Add(_db.CreateParameter("@ActionTypeId", dto.ActionTypeId));
             cmd.Parameters.Add(_db.CreateParameter("@ActionName", dto.ActionName));
             cmd.Parameters.Add(_db.CreateParameter("@ActionKey", dto.ActionKey));
@@ -570,7 +578,7 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
             _logger.LogInformation(
                 "Rule action created with id {ActionId} for rule {RuleId}.",
                 actionId,
-                dto.RuleId);
+                ruleId);
             return actionId;
         }
 

--- a/Services/Interfaces/IRulesAuthoringService.cs
+++ b/Services/Interfaces/IRulesAuthoringService.cs
@@ -13,14 +13,14 @@ namespace GMS.TifoXRCoreWebAPI.Services
     public interface IRulesAuthoringService
     {
         Task<RuleDetailView> GetRuleDetailAsync(int spaceId, int ruleId);
-        Task<RuleExpressionUpdateResult> UpdateRuleDefinitionAsync(RuleDefinitionUpdateDto dto);
-        Task<int> CreateWorkflowAsync(WorkflowCreateDto dto);
-        Task<int> CreateRuleAsync(RuleCreateDto dto);
+        Task<RuleExpressionUpdateResult> UpdateRuleDefinitionAsync(int spaceId, int ruleId, RuleDefinitionUpdateDto dto);
+        Task<int> CreateWorkflowAsync(int spaceId, WorkflowCreateDto dto);
+        Task<int> CreateRuleAsync(int spaceId, int workflowId, RuleCreateDto dto);
         Task<IReadOnlyList<int>> AddConditionGroupsAsync(int ruleId, IEnumerable<ConditionGroupCreateDto> groups);
         Task<IReadOnlyList<int>> AddConditionsAsync(int groupId, IEnumerable<ConditionCreateDto> conditions);
-        Task<RuleExpressionUpdateResult> UpdateConditionGroupAsync(ConditionGroupUpdateDto dto);
-        Task<RuleExpressionUpdateResult> UpdateConditionAsync(ConditionUpdateDto dto);
-        Task<int> CreateRuleActionAsync(RuleActionCreateDto dto);
+        Task<RuleExpressionUpdateResult> UpdateConditionGroupAsync(int ruleId, int groupId, ConditionGroupUpdateDto dto);
+        Task<RuleExpressionUpdateResult> UpdateConditionAsync(int groupId, int conditionId, ConditionUpdateDto dto);
+        Task<int> CreateRuleActionAsync(int ruleId, RuleActionCreateDto dto);
         Task BindRewardAsync(int actionId, int rewardId);
     }
 }

--- a/Services/RulesAuthoringService.cs
+++ b/Services/RulesAuthoringService.cs
@@ -63,55 +63,58 @@ namespace GMS.TifoXRCoreWebAPI.Services
             };
         }
 
-        public async Task<RuleExpressionUpdateResult> UpdateRuleDefinitionAsync(RuleDefinitionUpdateDto dto)
+        public async Task<RuleExpressionUpdateResult> UpdateRuleDefinitionAsync(
+            int spaceId,
+            int ruleId,
+            RuleDefinitionUpdateDto dto)
         {
             if (dto is null) throw new ArgumentNullException(nameof(dto));
 
-            var (exists, spaceId, _) = await _repo.TryGetRuleContextAsync(dto.RuleId);
+            var (exists, currentSpaceId, _) = await _repo.TryGetRuleContextAsync(ruleId);
             if (!exists)
-                throw new InvalidOperationException($"Rule {dto.RuleId} does not exist.");
+                throw new InvalidOperationException($"Rule {ruleId} does not exist.");
 
-            if (spaceId != dto.SpaceId)
+            if (currentSpaceId != spaceId)
                 throw new InvalidOperationException(
-                    $"Rule {dto.RuleId} belongs to space {spaceId} and cannot be updated from space {dto.SpaceId}.");
+                    $"Rule {ruleId} belongs to space {currentSpaceId} and cannot be updated from space {spaceId}.");
 
-            var groups = await _repo.GetRuleConditionGroupsAsync(dto.RuleId);
-            var conditions = await _repo.GetRuleConditionsAsync(dto.RuleId);
+            var groups = await _repo.GetRuleConditionGroupsAsync(ruleId);
+            var conditions = await _repo.GetRuleConditionsAsync(ruleId);
             var expression = ComposeExpression(groups, conditions);
 
-            await _repo.UpdateRuleDefinitionAsync(dto, expression);
-            _evaluationService.Invalidate(spaceId);
+            await _repo.UpdateRuleDefinitionAsync(ruleId, dto, expression);
+            _evaluationService.Invalidate(currentSpaceId);
 
             return new RuleExpressionUpdateResult
             {
-                RuleId = dto.RuleId,
+                RuleId = ruleId,
                 Expression = expression
             };
         }
 
-        public async Task<int> CreateWorkflowAsync(WorkflowCreateDto dto)
+        public async Task<int> CreateWorkflowAsync(int spaceId, WorkflowCreateDto dto)
         {
             if (dto is null) throw new ArgumentNullException(nameof(dto));
             var stateTypeId = await ResolveStateTypeIdAsync(dto.StateTypeId);
-            var id = await _repo.CreateWorkflowAsync(dto, stateTypeId);
-            _evaluationService.Invalidate(dto.SpaceId);
+            var id = await _repo.CreateWorkflowAsync(spaceId, dto, stateTypeId);
+            _evaluationService.Invalidate(spaceId);
             return id;
         }
 
-        public async Task<int> CreateRuleAsync(RuleCreateDto dto)
+        public async Task<int> CreateRuleAsync(int spaceId, int workflowId, RuleCreateDto dto)
         {
             if (dto is null) throw new ArgumentNullException(nameof(dto));
 
-            var (workflowExists, workflowSpace) = await _repo.TryGetWorkflowSpaceAsync(dto.WorkflowId);
+            var (workflowExists, workflowSpace) = await _repo.TryGetWorkflowSpaceAsync(workflowId);
             if (!workflowExists)
-                throw new InvalidOperationException($"Workflow {dto.WorkflowId} does not exist.");
+                throw new InvalidOperationException($"Workflow {workflowId} does not exist.");
 
-            if (workflowSpace != dto.SpaceId)
+            if (workflowSpace != spaceId)
                 throw new InvalidOperationException("Rule space id must match the workflow's space id.");
 
             var stateTypeId = await ResolveStateTypeIdAsync(dto.StateTypeId);
-            var id = await _repo.CreateRuleAsync(dto, stateTypeId);
-            _evaluationService.Invalidate(dto.SpaceId);
+            var id = await _repo.CreateRuleAsync(spaceId, workflowId, dto, stateTypeId);
+            _evaluationService.Invalidate(spaceId);
             return id;
         }
 
@@ -123,13 +126,7 @@ namespace GMS.TifoXRCoreWebAPI.Services
             if (!exists)
                 throw new InvalidOperationException($"Rule {ruleId} does not exist.");
 
-            foreach (var group in groups)
-            {
-                if (group.RuleId != ruleId)
-                    throw new InvalidOperationException("Condition group payload rule id must match the route rule id.");
-            }
-
-            var ids = await _repo.InsertConditionGroupsAsync(groups);
+            var ids = await _repo.InsertConditionGroupsAsync(ruleId, groups);
             _evaluationService.Invalidate(spaceId);
             return ids;
         }
@@ -142,66 +139,66 @@ namespace GMS.TifoXRCoreWebAPI.Services
             if (!exists)
                 throw new InvalidOperationException($"Condition group {groupId} does not exist.");
 
-            foreach (var condition in conditions)
-            {
-                if (condition.GroupId != groupId)
-                    throw new InvalidOperationException("Condition payload group id must match the route group id.");
-            }
-
-            var ids = await _repo.InsertConditionsAsync(conditions);
+            var ids = await _repo.InsertConditionsAsync(groupId, conditions);
             _evaluationService.Invalidate(spaceId);
             return ids;
         }
 
-        public async Task<RuleExpressionUpdateResult> UpdateConditionGroupAsync(ConditionGroupUpdateDto dto)
+        public async Task<RuleExpressionUpdateResult> UpdateConditionGroupAsync(
+            int ruleId,
+            int groupId,
+            ConditionGroupUpdateDto dto)
         {
             if (dto is null) throw new ArgumentNullException(nameof(dto));
 
-            var (exists, ruleId, spaceId) = await _repo.TryGetConditionGroupContextAsync(dto.Id);
+            var (exists, currentRuleId, spaceId) = await _repo.TryGetConditionGroupContextAsync(groupId);
             if (!exists)
-                throw new InvalidOperationException($"Condition group {dto.Id} does not exist.");
+                throw new InvalidOperationException($"Condition group {groupId} does not exist.");
 
-            if (dto.RuleId != ruleId)
+            if (currentRuleId != ruleId)
                 throw new InvalidOperationException(
-                    $"Condition group {dto.Id} belongs to rule {ruleId} and cannot be updated for rule {dto.RuleId}.");
+                    $"Condition group {groupId} belongs to rule {currentRuleId} and cannot be updated for rule {ruleId}.");
 
             if (dto.ParentGroupId.HasValue)
             {
-                var belongs = await _repo.ConditionGroupBelongsToRuleAsync(dto.ParentGroupId.Value, ruleId);
+                var belongs = await _repo.ConditionGroupBelongsToRuleAsync(dto.ParentGroupId.Value, currentRuleId);
                 if (!belongs)
                     throw new InvalidOperationException(
-                        $"Parent condition group {dto.ParentGroupId.Value} does not belong to rule {ruleId}.");
+                        $"Parent condition group {dto.ParentGroupId.Value} does not belong to rule {currentRuleId}.");
             }
 
-            await _repo.UpdateConditionGroupAsync(dto);
+            await _repo.UpdateConditionGroupAsync(groupId, dto);
 
-            var expression = await RefreshRuleExpressionAsync(ruleId);
+            var expression = await RefreshRuleExpressionAsync(currentRuleId);
             _evaluationService.Invalidate(spaceId);
 
             return new RuleExpressionUpdateResult
             {
-                RuleId = ruleId,
+                RuleId = currentRuleId,
                 Expression = expression
             };
         }
 
-        public async Task<RuleExpressionUpdateResult> UpdateConditionAsync(ConditionUpdateDto dto)
+        public async Task<RuleExpressionUpdateResult> UpdateConditionAsync(
+            int groupId,
+            int conditionId,
+            ConditionUpdateDto dto)
         {
             if (dto is null) throw new ArgumentNullException(nameof(dto));
 
-            var (exists, currentGroupId, ruleId, spaceId) = await _repo.TryGetConditionContextAsync(dto.Id);
+            var (exists, currentGroupId, ruleId, spaceId) = await _repo.TryGetConditionContextAsync(conditionId);
             if (!exists)
-                throw new InvalidOperationException($"Condition {dto.Id} does not exist.");
+                throw new InvalidOperationException($"Condition {conditionId} does not exist.");
 
-            if (dto.GroupId != currentGroupId)
+            if (groupId != currentGroupId)
             {
-                var belongs = await _repo.ConditionGroupBelongsToRuleAsync(dto.GroupId, ruleId);
+                var belongs = await _repo.ConditionGroupBelongsToRuleAsync(groupId, ruleId);
                 if (!belongs)
                     throw new InvalidOperationException(
-                        $"Condition group {dto.GroupId} does not belong to rule {ruleId}.");
+                        $"Condition group {groupId} does not belong to rule {ruleId}.");
             }
 
-            await _repo.UpdateConditionAsync(dto);
+            await _repo.UpdateConditionAsync(conditionId, groupId, dto);
 
             var expression = await RefreshRuleExpressionAsync(ruleId);
             _evaluationService.Invalidate(spaceId);
@@ -213,15 +210,15 @@ namespace GMS.TifoXRCoreWebAPI.Services
             };
         }
 
-        public async Task<int> CreateRuleActionAsync(RuleActionCreateDto dto)
+        public async Task<int> CreateRuleActionAsync(int ruleId, RuleActionCreateDto dto)
         {
             if (dto is null) throw new ArgumentNullException(nameof(dto));
 
-            var (ruleExists, spaceId, _) = await _repo.TryGetRuleContextAsync(dto.RuleId);
+            var (ruleExists, spaceId, _) = await _repo.TryGetRuleContextAsync(ruleId);
             if (!ruleExists)
-                throw new InvalidOperationException($"Rule {dto.RuleId} does not exist.");
+                throw new InvalidOperationException($"Rule {ruleId} does not exist.");
 
-            var id = await _repo.CreateRuleActionAsync(dto);
+            var id = await _repo.CreateRuleActionAsync(ruleId, dto);
             _evaluationService.Invalidate(spaceId);
             return id;
         }

--- a/TifoXRCoreWebAPI.Tests/Services/RulesAuthoringServiceTests.cs
+++ b/TifoXRCoreWebAPI.Tests/Services/RulesAuthoringServiceTests.cs
@@ -62,7 +62,10 @@ namespace TifoXRCoreWebAPI.Tests.Services
                 });
 
             repo
-                .Setup(r => r.UpdateRuleDefinitionAsync(It.IsAny<RuleDefinitionUpdateDto>(), It.IsAny<string>()))
+                .Setup(r => r.UpdateRuleDefinitionAsync(
+                    It.IsAny<int>(),
+                    It.IsAny<RuleDefinitionUpdateDto>(),
+                    It.IsAny<string>()))
                 .Returns(Task.CompletedTask);
 
             var service = new RulesAuthoringService(
@@ -73,17 +76,15 @@ namespace TifoXRCoreWebAPI.Tests.Services
 
             var dto = new RuleDefinitionUpdateDto
             {
-                RuleId = 1,
-                SpaceId = 42,
                 RuleName = "Test Rule",
                 Priority = 1,
                 RuleCooldownSeconds = 0
             };
 
-            var result = await service.UpdateRuleDefinitionAsync(dto);
+            var result = await service.UpdateRuleDefinitionAsync(42, 1, dto);
 
             result.Expression.Should().Be("ScoreValue >= 50");
-            repo.Verify(r => r.UpdateRuleDefinitionAsync(dto, "ScoreValue >= 50"), Times.Once);
+            repo.Verify(r => r.UpdateRuleDefinitionAsync(1, dto, "ScoreValue >= 50"), Times.Once);
             evaluation.Verify(e => e.Invalidate(42), Times.Once);
         }
 


### PR DESCRIPTION
## Summary
- drop route identifier fields from rules authoring DTOs so clients only send contextual data
- update controllers, services, and repositories to thread route parameters through business logic and persistence calls
- adjust unit tests to cover the new service signature for rule definition updates

## Testing
- dotnet build *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dfe5bb16348329a1d8b322b3bd1654