### PR TITLE
Refresh rule expression when adding conditions

### DIFF
--- a/Services/RulesAuthoringService.cs
+++ b/Services/RulesAuthoringService.cs
@@ -135,11 +135,12 @@ namespace GMS.TifoXRCoreWebAPI.Services
         {
             if (conditions is null) throw new ArgumentNullException(nameof(conditions));
 
-            var (exists, _, spaceId) = await _repo.TryGetConditionGroupContextAsync(groupId);
+            var (exists, ruleId, spaceId) = await _repo.TryGetConditionGroupContextAsync(groupId);
             if (!exists)
                 throw new InvalidOperationException($"Condition group {groupId} does not exist.");
 
             var ids = await _repo.InsertConditionsAsync(groupId, conditions);
+            await RefreshRuleExpressionAsync(ruleId);
             _evaluationService.Invalidate(spaceId);
             return ids;
         }

--- a/TifoXRCoreWebAPI.Tests/Services/RulesAuthoringServiceTests.cs
+++ b/TifoXRCoreWebAPI.Tests/Services/RulesAuthoringServiceTests.cs
@@ -248,6 +248,36 @@ namespace TifoXRCoreWebAPI.Tests.Services
                 .Setup(r => r.InsertConditionsAsync(15, It.IsAny<IEnumerable<ConditionCreateDto>>()))
                 .ReturnsAsync(expectedIds);
 
+            repo
+                .Setup(r => r.GetRuleConditionGroupsAsync(5))
+                .ReturnsAsync(new List<ConditionGroupDetailView>());
+
+            repo
+                .Setup(r => r.GetRuleConditionsAsync(5))
+                .ReturnsAsync(new List<ConditionDetailView>
+                {
+                    new()
+                    {
+                        Id = 21,
+                        GroupId = 15,
+                        ParameterId = 99,
+                        ComparatorId = 7,
+                        ComparatorCode = ComparatorCodes.Eq,
+                        ComparatorFormat = "{0} == {1}",
+                        ParameterKey = "Score",
+                        ParameterSource = "event",
+                        ParameterPath = "$.Score",
+                        Negate = false,
+                        RightValueKind = RightValueKinds.Literal,
+                        RightValueJson = "10",
+                        OrderIndex = 1
+                    }
+                });
+
+            repo
+                .Setup(r => r.UpdateRuleExpressionAsync(5, It.IsAny<string>()))
+                .Returns(Task.CompletedTask);
+
             var service = new RulesAuthoringService(
                 repo.Object,
                 rewardRepo.Object,
@@ -275,6 +305,9 @@ namespace TifoXRCoreWebAPI.Tests.Services
                     15,
                     It.Is<IEnumerable<ConditionCreateDto>>(c => ReferenceEquals(c, payload))),
                 Times.Once);
+            repo.Verify(r => r.GetRuleConditionGroupsAsync(5), Times.Once);
+            repo.Verify(r => r.GetRuleConditionsAsync(5), Times.Once);
+            repo.Verify(r => r.UpdateRuleExpressionAsync(5, "Score == 10"), Times.Once);
             evaluation.Verify(e => e.Invalidate(42), Times.Once);
         }
     }


### PR DESCRIPTION
## Summary
- recompute the rule expression whenever new conditions are added to a group
- extend the RulesAuthoringService tests to cover expression refresh on condition insertion

## Testing
- dotnet test *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e03e6a35c08329b1a0851d59bb90ba