### PR TITLE
Parse literal values from JSON when composing rule expressions

### DIFF
--- a/Services/RulesAuthoringService.cs
+++ b/Services/RulesAuthoringService.cs
@@ -354,11 +354,21 @@ namespace GMS.TifoXRCoreWebAPI.Services
                 ? "{0} == {1}"
                 : condition.ComparatorFormat;
 
-            var left = condition.ParameterKey;
-            var right = FormatRightValue(condition);
+            var left = EscapeFormatArgument(condition.ParameterKey);
+            var right = EscapeFormatArgument(FormatRightValue(condition));
             var expression = string.Format(CultureInfo.InvariantCulture, format, left, right);
 
             return condition.Negate ? $"!({expression})" : expression;
+        }
+
+        private static string EscapeFormatArgument(string? value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return value ?? string.Empty;
+            }
+
+            return value.Replace("{", "{{").Replace("}", "}}");
         }
 
         private static string CombineUsingFormat(string format, IReadOnlyList<string> expressions)
@@ -389,11 +399,13 @@ namespace GMS.TifoXRCoreWebAPI.Services
                 return "null";
             }
 
+            var json = condition.RightValueJson.Trim();
+
             if (string.Equals(condition.RightValueKind, RightValueKinds.Parameter, StringComparison.OrdinalIgnoreCase))
             {
                 try
                 {
-                    using var doc = JsonDocument.Parse(condition.RightValueJson);
+                    using var doc = JsonDocument.Parse(json);
                     var root = doc.RootElement;
 
                     if (root.ValueKind == JsonValueKind.String)
@@ -416,13 +428,41 @@ namespace GMS.TifoXRCoreWebAPI.Services
                 }
                 catch (JsonException)
                 {
-                    return condition.RightValueJson.Trim();
+                    return json;
                 }
 
                 return "null";
             }
 
-            return condition.RightValueJson.Trim();
+            try
+            {
+                using var doc = JsonDocument.Parse(json);
+                var root = doc.RootElement;
+
+                if (root.ValueKind == JsonValueKind.Object && root.TryGetProperty("value", out var valueProperty))
+                {
+                    return FormatLiteralElement(valueProperty);
+                }
+
+                return FormatLiteralElement(root);
+            }
+            catch (JsonException)
+            {
+                return json;
+            }
+        }
+
+        private static string FormatLiteralElement(JsonElement element)
+        {
+            return element.ValueKind switch
+            {
+                JsonValueKind.Null => "null",
+                JsonValueKind.String => element.GetRawText(),
+                JsonValueKind.Number => element.GetRawText(),
+                JsonValueKind.True => element.GetRawText(),
+                JsonValueKind.False => element.GetRawText(),
+                _ => element.GetRawText(),
+            };
         }
     }
 }

--- a/TifoXRCoreWebAPI.Tests/Services/RulesAuthoringServiceTests.cs
+++ b/TifoXRCoreWebAPI.Tests/Services/RulesAuthoringServiceTests.cs
@@ -310,5 +310,151 @@ namespace TifoXRCoreWebAPI.Tests.Services
             repo.Verify(r => r.UpdateRuleExpressionAsync(5, "Score == 10"), Times.Once);
             evaluation.Verify(e => e.Invalidate(42), Times.Once);
         }
+
+        [Fact]
+        public async Task AddConditionsAsync_UsesLiteralValueFromJsonObject()
+        {
+            var repo = new Mock<IRulesRepository>();
+            var rewardRepo = new Mock<IRewardRepository>();
+            var evaluation = new Mock<IRulesEvaluationService>();
+            var metadata = new Mock<IRulesMetadataRepository>();
+
+            repo
+                .Setup(r => r.TryGetConditionGroupContextAsync(15))
+                .ReturnsAsync((true, 5, 42));
+
+            repo
+                .Setup(r => r.InsertConditionsAsync(15, It.IsAny<IEnumerable<ConditionCreateDto>>()))
+                .ReturnsAsync(new List<int> { 21 });
+
+            repo
+                .Setup(r => r.GetRuleConditionGroupsAsync(5))
+                .ReturnsAsync(new List<ConditionGroupDetailView>());
+
+            repo
+                .Setup(r => r.GetRuleConditionsAsync(5))
+                .ReturnsAsync(new List<ConditionDetailView>
+                {
+                    new()
+                    {
+                        Id = 21,
+                        GroupId = 15,
+                        ParameterId = 99,
+                        ComparatorId = 7,
+                        ComparatorCode = ComparatorCodes.Eq,
+                        ComparatorFormat = "{0} == {1}",
+                        ParameterKey = "Score",
+                        ParameterSource = "event",
+                        ParameterPath = "$.Score",
+                        Negate = false,
+                        RightValueKind = RightValueKinds.Literal,
+                        RightValueJson = "{\"value\":10}",
+                        OrderIndex = 1
+                    }
+                });
+
+            repo
+                .Setup(r => r.UpdateRuleExpressionAsync(5, It.IsAny<string>()))
+                .Returns(Task.CompletedTask);
+
+            var service = new RulesAuthoringService(
+                repo.Object,
+                rewardRepo.Object,
+                evaluation.Object,
+                metadata.Object);
+
+            var payload = new[]
+            {
+                new ConditionCreateDto
+                {
+                    ParameterId = 99,
+                    ComparatorId = 7,
+                    Negate = false,
+                    RightValueKind = RightValueKinds.Literal,
+                    RightValueJson = "{\"value\":10}",
+                    OrderIndex = 1
+                }
+            };
+
+            var ids = await service.AddConditionsAsync(15, payload);
+
+            ids.Should().BeEquivalentTo(new List<int> { 21 });
+            repo.Verify(
+                r => r.UpdateRuleExpressionAsync(5, "Score == 10"),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task AddConditionsAsync_FormatsStringLiteralFromJsonObject()
+        {
+            var repo = new Mock<IRulesRepository>();
+            var rewardRepo = new Mock<IRewardRepository>();
+            var evaluation = new Mock<IRulesEvaluationService>();
+            var metadata = new Mock<IRulesMetadataRepository>();
+
+            repo
+                .Setup(r => r.TryGetConditionGroupContextAsync(15))
+                .ReturnsAsync((true, 5, 42));
+
+            repo
+                .Setup(r => r.InsertConditionsAsync(15, It.IsAny<IEnumerable<ConditionCreateDto>>()))
+                .ReturnsAsync(new List<int> { 21 });
+
+            repo
+                .Setup(r => r.GetRuleConditionGroupsAsync(5))
+                .ReturnsAsync(new List<ConditionGroupDetailView>());
+
+            repo
+                .Setup(r => r.GetRuleConditionsAsync(5))
+                .ReturnsAsync(new List<ConditionDetailView>
+                {
+                    new()
+                    {
+                        Id = 21,
+                        GroupId = 15,
+                        ParameterId = 99,
+                        ComparatorId = 7,
+                        ComparatorCode = ComparatorCodes.Eq,
+                        ComparatorFormat = "{0} == {1}",
+                        ParameterKey = "Tier",
+                        ParameterSource = "event",
+                        ParameterPath = "$.Tier",
+                        Negate = false,
+                        RightValueKind = RightValueKinds.Literal,
+                        RightValueJson = "{\"value\":\"Bronze\"}",
+                        OrderIndex = 1
+                    }
+                });
+
+            repo
+                .Setup(r => r.UpdateRuleExpressionAsync(5, It.IsAny<string>()))
+                .Returns(Task.CompletedTask);
+
+            var service = new RulesAuthoringService(
+                repo.Object,
+                rewardRepo.Object,
+                evaluation.Object,
+                metadata.Object);
+
+            var payload = new[]
+            {
+                new ConditionCreateDto
+                {
+                    ParameterId = 99,
+                    ComparatorId = 7,
+                    Negate = false,
+                    RightValueKind = RightValueKinds.Literal,
+                    RightValueJson = "{\"value\":\"Bronze\"}",
+                    OrderIndex = 1
+                }
+            };
+
+            var ids = await service.AddConditionsAsync(15, payload);
+
+            ids.Should().BeEquivalentTo(new List<int> { 21 });
+            repo.Verify(
+                r => r.UpdateRuleExpressionAsync(5, "Tier == \"Bronze\""),
+                Times.Once);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- parse literal condition payloads to extract the concrete value before formatting rule expressions
- add unit tests covering numeric and string literals supplied as JSON objects

## Testing
- dotnet test *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e0488a0f6083299bdaaf6a12d76831