### PR TITLE
Handle invalid comparator formats when composing rule expressions

### DIFF
--- a/Services/RulesAuthoringService.cs
+++ b/Services/RulesAuthoringService.cs
@@ -23,6 +23,23 @@ namespace GMS.TifoXRCoreWebAPI.Services
         private readonly IRulesMetadataRepository _metadataRepo;
         private const string DefaultStateTypeName = "Published";
 
+        private static readonly IReadOnlyDictionary<string, string> ComparatorFallbackFormats =
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                [ComparatorCodes.Eq] = "{0} == {1}",
+                [ComparatorCodes.Neq] = "{0} != {1}",
+                [ComparatorCodes.Gt] = "{0} > {1}",
+                [ComparatorCodes.Gte] = "{0} >= {1}",
+                [ComparatorCodes.Lt] = "{0} < {1}",
+                [ComparatorCodes.Lte] = "{0} <= {1}",
+                [ComparatorCodes.Contains] = "{0}.Contains({1})",
+                [ComparatorCodes.StartsWith] = "{0}.StartsWith({1})",
+                [ComparatorCodes.EndsWith] = "{0}.EndsWith({1})",
+                [ComparatorCodes.In] = "{1}.Contains({0})",
+                [ComparatorCodes.NotIn] = "!{1}.Contains({0})",
+                [ComparatorCodes.Exists] = "{0} != null"
+            };
+
         public RulesAuthoringService(
             IRulesRepository repo,
             IRewardRepository rewardRepo,
@@ -351,15 +368,35 @@ namespace GMS.TifoXRCoreWebAPI.Services
 
         private static string ComposeCondition(ConditionDetailView condition)
         {
-            var format = string.IsNullOrWhiteSpace(condition.ComparatorFormat)
-                ? "{0} == {1}"
-                : condition.ComparatorFormat;
-
             var left = EscapeFormatArgument(condition.ParameterKey);
             var right = EscapeFormatArgument(FormatRightValue(condition));
-            var expression = string.Format(CultureInfo.InvariantCulture, format, left, right);
+            var format = string.IsNullOrWhiteSpace(condition.ComparatorFormat)
+                ? GetComparatorFallbackFormat(condition.ComparatorCode)
+                : condition.ComparatorFormat;
+
+            string expression;
+            try
+            {
+                expression = string.Format(CultureInfo.InvariantCulture, format, left, right);
+            }
+            catch (FormatException)
+            {
+                var fallback = GetComparatorFallbackFormat(condition.ComparatorCode);
+                expression = string.Format(CultureInfo.InvariantCulture, fallback, left, right);
+            }
 
             return condition.Negate ? $"!({expression})" : expression;
+        }
+
+        private static string GetComparatorFallbackFormat(string? comparatorCode)
+        {
+            if (!string.IsNullOrWhiteSpace(comparatorCode) &&
+                ComparatorFallbackFormats.TryGetValue(comparatorCode, out var format))
+            {
+                return format;
+            }
+
+            return "{0} == {1}";
         }
 
         private static string EscapeFormatArgument(string? value)

--- a/TifoXRCoreWebAPI.Tests/Services/RulesAuthoringServiceTests.cs
+++ b/TifoXRCoreWebAPI.Tests/Services/RulesAuthoringServiceTests.cs
@@ -385,6 +385,77 @@ namespace TifoXRCoreWebAPI.Tests.Services
         }
 
         [Fact]
+        public async Task AddConditionsAsync_FallsBackWhenComparatorFormatInvalid()
+        {
+            var repo = new Mock<IRulesRepository>();
+            var rewardRepo = new Mock<IRewardRepository>();
+            var evaluation = new Mock<IRulesEvaluationService>();
+            var metadata = new Mock<IRulesMetadataRepository>();
+
+            repo
+                .Setup(r => r.TryGetConditionGroupContextAsync(15))
+                .ReturnsAsync((true, 5, 42));
+
+            repo
+                .Setup(r => r.InsertConditionsAsync(15, It.IsAny<IEnumerable<ConditionCreateDto>>()))
+                .ReturnsAsync(new List<int> { 21 });
+
+            repo
+                .Setup(r => r.GetRuleConditionGroupsAsync(5))
+                .ReturnsAsync(new List<ConditionGroupDetailView>());
+
+            repo
+                .Setup(r => r.GetRuleConditionsAsync(5))
+                .ReturnsAsync(new List<ConditionDetailView>
+                {
+                    new()
+                    {
+                        Id = 21,
+                        GroupId = 15,
+                        ParameterId = 99,
+                        ComparatorId = 7,
+                        ComparatorCode = ComparatorCodes.Eq,
+                        ComparatorFormat = "{Left} == {Right}",
+                        ParameterKey = "Score",
+                        ParameterSource = "event",
+                        ParameterPath = "$.Score",
+                        Negate = false,
+                        RightValueKind = RightValueKinds.Literal,
+                        RightValueJson = "{\"value\":10}",
+                        OrderIndex = 1
+                    }
+                });
+
+            repo
+                .Setup(r => r.UpdateRuleExpressionAsync(5, It.IsAny<string>()))
+                .Returns(Task.CompletedTask);
+
+            var service = new RulesAuthoringService(
+                repo.Object,
+                rewardRepo.Object,
+                evaluation.Object,
+                metadata.Object);
+
+            var payload = new[]
+            {
+                new ConditionCreateDto
+                {
+                    ParameterId = 99,
+                    ComparatorId = 7,
+                    Negate = false,
+                    RightValueKind = RightValueKinds.Literal,
+                    RightValueJson = "{\"value\":10}",
+                    OrderIndex = 1
+                }
+            };
+
+            await service.AddConditionsAsync(15, payload);
+
+            repo.Verify(r => r.UpdateRuleExpressionAsync(5, "Score == 10"), Times.Once);
+            evaluation.Verify(e => e.Invalidate(42), Times.Once);
+        }
+
+        [Fact]
         public async Task AddConditionsAsync_FormatsStringLiteralFromJsonObject()
         {
             var repo = new Mock<IRulesRepository>();


### PR DESCRIPTION
## Summary
- add comparator fallback formats and guard rule expression composition against invalid format strings
- add a unit test to ensure rule expressions fall back to safe formatting when comparator templates are malformed

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e04fcf05e08329b4fa3fd4a0d95d88