### PR TITLE
Normalize IN comparator expression output

### DIFF
--- a/Controllers/RulesAuthoringController.cs
+++ b/Controllers/RulesAuthoringController.cs
@@ -135,8 +135,8 @@ namespace GMS.TifoXRCoreWebAPI.Controllers
                     parameters: new { groupId });
 
 
-            var ids = await _svc.AddConditionsAsync(groupId, dtos);
-            return Ok(new { ids });
+            var result = await _svc.AddConditionsAsync(groupId, dtos);
+            return Ok(new { ids = result.Ids, expression = result.Expression });
         }
 
         [HttpPut("rules/{ruleId:int}/condition-groups/{groupId:int}")]

--- a/Models/RulesModels.cs
+++ b/Models/RulesModels.cs
@@ -5,6 +5,8 @@
 // <date>09/24/2025</date>
 // <summary>DTOs for Rules Engine authoring, runtime ingestion, and auditing.</summary>
 
+using System;
+using System.Collections.Generic;
 using System.Text.Json;
 
 namespace GMS.TifoXRCoreWebAPI.Models
@@ -283,6 +285,12 @@ namespace GMS.TifoXRCoreWebAPI.Models
     public sealed class RuleExpressionUpdateResult
     {
         public int RuleId { get; init; }
+        public string Expression { get; init; } = string.Empty;
+    }
+
+    public sealed class ConditionCreateResult
+    {
+        public IReadOnlyList<int> Ids { get; init; } = Array.Empty<int>();
         public string Expression { get; init; } = string.Empty;
     }
 

--- a/Services/Interfaces/IRulesAuthoringService.cs
+++ b/Services/Interfaces/IRulesAuthoringService.cs
@@ -17,7 +17,7 @@ namespace GMS.TifoXRCoreWebAPI.Services
         Task<int> CreateWorkflowAsync(int spaceId, WorkflowCreateDto dto);
         Task<int> CreateRuleAsync(int spaceId, int workflowId, RuleCreateDto dto);
         Task<IReadOnlyList<int>> AddConditionGroupsAsync(int ruleId, IEnumerable<ConditionGroupCreateDto> groups);
-        Task<IReadOnlyList<int>> AddConditionsAsync(int groupId, IEnumerable<ConditionCreateDto> conditions);
+        Task<ConditionCreateResult> AddConditionsAsync(int groupId, IEnumerable<ConditionCreateDto> conditions);
         Task<RuleExpressionUpdateResult> UpdateConditionGroupAsync(int ruleId, int groupId, ConditionGroupUpdateDto dto);
         Task<RuleExpressionUpdateResult> UpdateConditionAsync(int groupId, int conditionId, ConditionUpdateDto dto);
         Task<int> CreateRuleActionAsync(int ruleId, RuleActionCreateDto dto);

--- a/Services/RulesAuthoringService.cs
+++ b/Services/RulesAuthoringService.cs
@@ -148,7 +148,7 @@ namespace GMS.TifoXRCoreWebAPI.Services
             return ids;
         }
 
-        public async Task<IReadOnlyList<int>> AddConditionsAsync(int groupId, IEnumerable<ConditionCreateDto> conditions)
+        public async Task<ConditionCreateResult> AddConditionsAsync(int groupId, IEnumerable<ConditionCreateDto> conditions)
         {
             if (conditions is null) throw new ArgumentNullException(nameof(conditions));
 
@@ -157,9 +157,13 @@ namespace GMS.TifoXRCoreWebAPI.Services
                 throw new InvalidOperationException($"Condition group {groupId} does not exist.");
 
             var ids = await _repo.InsertConditionsAsync(groupId, conditions);
-            await RefreshRuleExpressionAsync(ruleId);
+            var expression = await RefreshRuleExpressionAsync(ruleId);
             _evaluationService.Invalidate(spaceId);
-            return ids;
+            return new ConditionCreateResult
+            {
+                Ids = ids,
+                Expression = expression
+            };
         }
 
         public async Task<RuleExpressionUpdateResult> UpdateConditionGroupAsync(
@@ -369,6 +373,12 @@ namespace GMS.TifoXRCoreWebAPI.Services
         private static string ComposeCondition(ConditionDetailView condition)
         {
             var left = EscapeFormatArgument(condition.ParameterKey);
+
+            if (TryFormatInListExpression(condition, left, out var listExpression))
+            {
+                return condition.Negate ? $"!({listExpression})" : listExpression;
+            }
+
             var right = EscapeFormatArgument(FormatRightValue(condition));
             var format = string.IsNullOrWhiteSpace(condition.ComparatorFormat)
                 ? GetComparatorFallbackFormat(condition.ComparatorCode)
@@ -386,6 +396,57 @@ namespace GMS.TifoXRCoreWebAPI.Services
             }
 
             return condition.Negate ? $"!({expression})" : expression;
+        }
+
+        private static bool TryFormatInListExpression(ConditionDetailView condition, string left, out string expression)
+        {
+            expression = string.Empty;
+
+            if (!string.Equals(condition.ComparatorCode, ComparatorCodes.In, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            if (!string.Equals(condition.RightValueKind, RightValueKinds.List, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(condition.RightValueJson))
+            {
+                return false;
+            }
+
+            try
+            {
+                using var doc = JsonDocument.Parse(condition.RightValueJson);
+                if (doc.RootElement.ValueKind != JsonValueKind.Array)
+                {
+                    return false;
+                }
+
+                var comparisons = new List<string>();
+                foreach (var element in doc.RootElement.EnumerateArray())
+                {
+                    var formattedValue = FormatLiteralElement(element);
+                    comparisons.Add($"{left} == {formattedValue}");
+                }
+
+                if (comparisons.Count == 0)
+                {
+                    expression = "false";
+                }
+                else
+                {
+                    expression = CombineUsingFormat("({0} || {1})", comparisons);
+                }
+
+                return true;
+            }
+            catch (JsonException)
+            {
+                return false;
+            }
         }
 
         private static string GetComparatorFallbackFormat(string? comparatorCode)

--- a/TifoXRCoreWebAPI.Tests/Services/RulesAuthoringServiceTests.cs
+++ b/TifoXRCoreWebAPI.Tests/Services/RulesAuthoringServiceTests.cs
@@ -297,9 +297,10 @@ namespace TifoXRCoreWebAPI.Tests.Services
                 }
             };
 
-            var ids = await service.AddConditionsAsync(15, payload);
+            var result = await service.AddConditionsAsync(15, payload);
 
-            ids.Should().BeEquivalentTo(expectedIds);
+            result.Ids.Should().BeEquivalentTo(expectedIds);
+            result.Expression.Should().Be("Score == 10");
             repo.Verify(
                 r => r.InsertConditionsAsync(
                     15,
@@ -376,9 +377,10 @@ namespace TifoXRCoreWebAPI.Tests.Services
                 }
             };
 
-            var ids = await service.AddConditionsAsync(15, payload);
+            var result = await service.AddConditionsAsync(15, payload);
 
-            ids.Should().BeEquivalentTo(new List<int> { 21 });
+            result.Ids.Should().BeEquivalentTo(new List<int> { 21 });
+            result.Expression.Should().Be("Score == 10");
             repo.Verify(
                 r => r.UpdateRuleExpressionAsync(5, "Score == 10"),
                 Times.Once);
@@ -449,10 +451,11 @@ namespace TifoXRCoreWebAPI.Tests.Services
                 }
             };
 
-            await service.AddConditionsAsync(15, payload);
+            var result = await service.AddConditionsAsync(15, payload);
 
             repo.Verify(r => r.UpdateRuleExpressionAsync(5, "Score == 10"), Times.Once);
             evaluation.Verify(e => e.Invalidate(42), Times.Once);
+            result.Expression.Should().Be("Score == 10");
         }
 
         [Fact]
@@ -520,11 +523,86 @@ namespace TifoXRCoreWebAPI.Tests.Services
                 }
             };
 
-            var ids = await service.AddConditionsAsync(15, payload);
+            var result = await service.AddConditionsAsync(15, payload);
 
-            ids.Should().BeEquivalentTo(new List<int> { 21 });
+            result.Ids.Should().BeEquivalentTo(new List<int> { 21 });
+            result.Expression.Should().Be("Tier == \"Bronze\"");
             repo.Verify(
                 r => r.UpdateRuleExpressionAsync(5, "Tier == \"Bronze\""),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task AddConditionsAsync_ComposesInComparatorWithListValues()
+        {
+            var repo = new Mock<IRulesRepository>();
+            var rewardRepo = new Mock<IRewardRepository>();
+            var evaluation = new Mock<IRulesEvaluationService>();
+            var metadata = new Mock<IRulesMetadataRepository>();
+
+            repo
+                .Setup(r => r.TryGetConditionGroupContextAsync(15))
+                .ReturnsAsync((true, 5, 42));
+
+            repo
+                .Setup(r => r.InsertConditionsAsync(15, It.IsAny<IEnumerable<ConditionCreateDto>>()))
+                .ReturnsAsync(new List<int> { 21 });
+
+            repo
+                .Setup(r => r.GetRuleConditionGroupsAsync(5))
+                .ReturnsAsync(new List<ConditionGroupDetailView>());
+
+            repo
+                .Setup(r => r.GetRuleConditionsAsync(5))
+                .ReturnsAsync(new List<ConditionDetailView>
+                {
+                    new()
+                    {
+                        Id = 21,
+                        GroupId = 15,
+                        ParameterId = 99,
+                        ComparatorId = 7,
+                        ComparatorCode = ComparatorCodes.In,
+                        ComparatorFormat = "{0} IN ({1})",
+                        ParameterKey = "Difficulty",
+                        ParameterSource = "event",
+                        ParameterPath = "$.difficulty",
+                        Negate = false,
+                        RightValueKind = RightValueKinds.List,
+                        RightValueJson = "[\"medium\", \"hard\"]",
+                        OrderIndex = 1
+                    }
+                });
+
+            repo
+                .Setup(r => r.UpdateRuleExpressionAsync(5, It.IsAny<string>()))
+                .Returns(Task.CompletedTask);
+
+            var service = new RulesAuthoringService(
+                repo.Object,
+                rewardRepo.Object,
+                evaluation.Object,
+                metadata.Object);
+
+            var payload = new[]
+            {
+                new ConditionCreateDto
+                {
+                    ParameterId = 99,
+                    ComparatorId = 7,
+                    Negate = false,
+                    RightValueKind = RightValueKinds.List,
+                    RightValueJson = "[\"medium\", \"hard\"]",
+                    OrderIndex = 1
+                }
+            };
+
+            var result = await service.AddConditionsAsync(15, payload);
+
+            result.Ids.Should().BeEquivalentTo(new List<int> { 21 });
+            result.Expression.Should().Be("(Difficulty == \"medium\" || Difficulty == \"hard\")");
+            repo.Verify(
+                r => r.UpdateRuleExpressionAsync(5, "(Difficulty == \"medium\" || Difficulty == \"hard\")"),
                 Times.Once);
         }
     }


### PR DESCRIPTION
## Summary
- convert IN comparator conditions backed by list values into OR-chained equality expressions when composing rules
- return the updated rule expression alongside newly created condition identifiers
- extend controller response and unit tests to cover the new behavior, including a case for IN list comparisons

## Testing
- dotnet test *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e05360ba6c83299118e60fa1dec7bc