### PR TITLE
Fix logical operator format fallback

### DIFF
--- a/Services/RulesAuthoringService.cs
+++ b/Services/RulesAuthoringService.cs
@@ -22,6 +22,7 @@ namespace GMS.TifoXRCoreWebAPI.Services
         private readonly IRulesEvaluationService _evaluationService;
         private readonly IRulesMetadataRepository _metadataRepo;
         private const string DefaultStateTypeName = "Published";
+        private const string DefaultLogicalOperatorFormat = "({0} && {1})";
 
         private static readonly IReadOnlyDictionary<string, string> ComparatorFallbackFormats =
             new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
@@ -363,11 +364,35 @@ namespace GMS.TifoXRCoreWebAPI.Services
                 return string.Empty;
             }
 
-            var format = string.IsNullOrWhiteSpace(group.LogicalOperatorFormat)
-                ? "({0} && {1})"
-                : group.LogicalOperatorFormat;
+            var format = GetLogicalOperatorFormat(group.LogicalOperatorFormat);
 
             return CombineUsingFormat(format, parts);
+        }
+
+        private static string GetLogicalOperatorFormat(string? format)
+        {
+            if (string.IsNullOrWhiteSpace(format))
+            {
+                return DefaultLogicalOperatorFormat;
+            }
+
+            var trimmed = format.Trim();
+
+            if (!trimmed.Contains("{0}", StringComparison.Ordinal) ||
+                !trimmed.Contains("{1}", StringComparison.Ordinal))
+            {
+                return DefaultLogicalOperatorFormat;
+            }
+
+            try
+            {
+                _ = string.Format(CultureInfo.InvariantCulture, trimmed, "left", "right");
+                return trimmed;
+            }
+            catch (FormatException)
+            {
+                return DefaultLogicalOperatorFormat;
+            }
         }
 
         private static string ComposeCondition(ConditionDetailView condition)

--- a/TifoXRCoreWebAPI.Tests/Services/RulesAuthoringServiceTests.cs
+++ b/TifoXRCoreWebAPI.Tests/Services/RulesAuthoringServiceTests.cs
@@ -89,6 +89,99 @@ namespace TifoXRCoreWebAPI.Tests.Services
         }
 
         [Fact]
+        public async Task UpdateRuleDefinitionAsync_FallsBackToDefaultLogicalOperatorFormatWhenInvalid()
+        {
+            var repo = new Mock<IRulesRepository>();
+            var rewardRepo = new Mock<IRewardRepository>();
+            var evaluation = new Mock<IRulesEvaluationService>();
+            var metadata = new Mock<IRulesMetadataRepository>();
+
+            repo
+                .Setup(r => r.TryGetRuleContextAsync(1))
+                .ReturnsAsync((true, 42, 7));
+
+            repo
+                .Setup(r => r.GetRuleConditionGroupsAsync(1))
+                .ReturnsAsync(new List<ConditionGroupDetailView>
+                {
+                    new()
+                    {
+                        Id = 100,
+                        RuleId = 1,
+                        ParentGroupId = null,
+                        LogicalOperatorId = 1,
+                        LogicalOperatorCode = "and",
+                        LogicalOperatorFormat = "&&",
+                        OrderIndex = 1
+                    }
+                });
+
+            repo
+                .Setup(r => r.GetRuleConditionsAsync(1))
+                .ReturnsAsync(new List<ConditionDetailView>
+                {
+                    new()
+                    {
+                        Id = 200,
+                        GroupId = 100,
+                        ParameterId = 10,
+                        ComparatorId = 5,
+                        ComparatorCode = ComparatorCodes.Gte,
+                        ComparatorFormat = "{0} >= {1}",
+                        ParameterKey = "ScoreValue",
+                        ParameterSource = "event",
+                        ParameterPath = "$.ScoreValue",
+                        Negate = false,
+                        RightValueKind = RightValueKinds.Literal,
+                        RightValueJson = "50",
+                        OrderIndex = 1
+                    },
+                    new()
+                    {
+                        Id = 201,
+                        GroupId = 100,
+                        ParameterId = 11,
+                        ComparatorId = 6,
+                        ComparatorCode = ComparatorCodes.Lte,
+                        ComparatorFormat = "{0} <= {1}",
+                        ParameterKey = "Attempts",
+                        ParameterSource = "event",
+                        ParameterPath = "$.Attempts",
+                        Negate = false,
+                        RightValueKind = RightValueKinds.Literal,
+                        RightValueJson = "10",
+                        OrderIndex = 2
+                    }
+                });
+
+            repo
+                .Setup(r => r.UpdateRuleDefinitionAsync(
+                    It.IsAny<int>(),
+                    It.IsAny<RuleDefinitionUpdateDto>(),
+                    It.IsAny<string>()))
+                .Returns(Task.CompletedTask);
+
+            var service = new RulesAuthoringService(
+                repo.Object,
+                rewardRepo.Object,
+                evaluation.Object,
+                metadata.Object);
+
+            var dto = new RuleDefinitionUpdateDto
+            {
+                RuleName = "Test Rule",
+                Priority = 1,
+                RuleCooldownSeconds = 0
+            };
+
+            var result = await service.UpdateRuleDefinitionAsync(42, 1, dto);
+
+            result.Expression.Should().Be("(ScoreValue >= 50 && Attempts <= 10)");
+            repo.Verify(r => r.UpdateRuleDefinitionAsync(1, dto, "(ScoreValue >= 50 && Attempts <= 10)"), Times.Once);
+            evaluation.Verify(e => e.Invalidate(42), Times.Once);
+        }
+
+        [Fact]
         public async Task GetRuleDetailAsync_ReturnsAggregatedView()
         {
             var repo = new Mock<IRulesRepository>();


### PR DESCRIPTION
## Summary
- ensure invalid logical operator formats fall back to the default when composing rule expressions
- add a unit test covering the fallback behavior for malformed logical operator formats

## Testing
- dotnet test *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e055a9707c8329b97b139a729de0df