### PR TITLE
Add booth media support to booth repository and tests

### DIFF
--- a/Models/BoothModel.cs
+++ b/Models/BoothModel.cs
@@ -16,6 +16,8 @@ namespace GMS.TifoXRCoreWebAPI.Models
 
         public MapSpotModel MapSpot { get; set; }
 
+        public List<MediaCreateDto>? MediaItems { get; set; }
+
     }
 
     public class BoothWrapper
@@ -30,6 +32,7 @@ namespace GMS.TifoXRCoreWebAPI.Models
         public int MapSpotId { get; set; }
         public MapSpotModel? MapSpot { get; set; }
         public LocalizedPairs LocalizedPairs { get; set; }
+        public List<MediaData> MediaItems { get; set; } = new();
     }
     public class MapSpotModel
     {
@@ -45,6 +48,8 @@ namespace GMS.TifoXRCoreWebAPI.Models
         public int MapSpotId { get; set; }
 
         public MapSpotModel MapSpot { get; set; }
+
+        public List<MediaUpdateDto>? MediaItems { get; set; }
 
     }
 

--- a/Repositories/BoothRepository.cs
+++ b/Repositories/BoothRepository.cs
@@ -5,8 +5,11 @@
 // <date>08/18/2025</date>
 // <summary>Class to handle booth SQL side</summary>
 
+using System;
+using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
+using System.Linq;
 //
 using GMS.TifoXRCoreWebAPI.Models;
 using GMS.TifoXRCoreWebAPI.Models.Common;
@@ -98,7 +101,8 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
                         {
                             Key = reader.GetString(o_name_key),
                             Values = new List<LocalizedValue>()
-                        }
+                        },
+                        MediaItems = new List<MediaData>()
                     };
 
                     booths[id] = booth;
@@ -118,7 +122,546 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
                 }
             }
 
+            if (booths.Count > 0)
+            {
+                await LoadBoothMediaAsync(conn, booths, spaceId);
+            }
+
             return booths.Values.ToList();
+        }
+
+        private async Task LoadBoothMediaAsync(DbConnection conn, IDictionary<int, BoothModel> booths, int spaceId)
+        {
+            if (booths is null || booths.Count == 0)
+            {
+                return;
+            }
+
+            var boothIds = booths.Keys.ToList();
+            var paramNames = boothIds.Select((_, i) => $"@B{i}").ToList();
+
+            var sql = $@"
+            SELECT
+                bm.booth_id,
+                bm.media_id,
+                m.media_type_id,
+                m.text_key,
+                m.description_key,
+                ml.locale_id,
+                ml.media_link
+            FROM booth_media bm
+            INNER JOIN media m
+                ON bm.media_id = m.id
+            LEFT JOIN media_localization ml
+                ON ml.media_id = m.id
+            WHERE bm.booth_id IN ({string.Join(", ", paramNames)})
+              AND m.space_id = @SpaceId
+            ORDER BY bm.booth_id, bm.media_id, ml.locale_id;";
+
+            await using var cmd = _db.CreateCommand(conn, sql);
+            for (int i = 0; i < boothIds.Count; i++)
+            {
+                cmd.Parameters.Add(_db.CreateParameter(paramNames[i], boothIds[i]));
+            }
+
+            cmd.Parameters.Add(_db.CreateParameter("@SpaceId", spaceId));
+
+            await using var reader = await cmd.ExecuteReaderAsync();
+
+            var mediaCache = new Dictionary<(int BoothId, string MediaId), MediaData>();
+
+            bool ordReady = false;
+            int oBooth = -1, oMedia = -1, oType = -1, oText = -1, oDesc = -1, oLocale = -1, oLink = -1;
+
+            while (await reader.ReadAsync())
+            {
+                if (!ordReady)
+                {
+                    oBooth = reader.GetOrdinal("booth_id");
+                    oMedia = reader.GetOrdinal("media_id");
+                    oType = reader.GetOrdinal("media_type_id");
+                    oText = reader.GetOrdinal("text_key");
+                    oDesc = reader.GetOrdinal("description_key");
+                    oLocale = reader.GetOrdinal("locale_id");
+                    oLink = reader.GetOrdinal("media_link");
+                    ordReady = true;
+                }
+
+                var boothId = reader.GetInt32(oBooth);
+                if (!booths.TryGetValue(boothId, out var booth))
+                {
+                    continue;
+                }
+
+                var mediaId = reader.GetString(oMedia);
+                var key = (boothId, mediaId);
+
+                if (!mediaCache.TryGetValue(key, out var media))
+                {
+                    media = new MediaData
+                    {
+                        Id = mediaId,
+                        MediaTypeId = reader.GetInt32(oType),
+                        TextKey = reader.IsDBNull(oText) ? null : reader.GetString(oText),
+                        DescriptionKey = reader.IsDBNull(oDesc) ? null : reader.GetString(oDesc),
+                        LinkLocalizations = new List<MediaLocalization>()
+                    };
+
+                    mediaCache[key] = media;
+                    booth.MediaItems.Add(media);
+                }
+
+                if (!reader.IsDBNull(oLocale) && !reader.IsDBNull(oLink))
+                {
+                    var locale = reader.GetString(oLocale);
+
+                    if (!media.LinkLocalizations.Any(l => string.Equals(l.LocaleId, locale, StringComparison.OrdinalIgnoreCase)))
+                    {
+                        media.LinkLocalizations.Add(new MediaLocalization
+                        {
+                            LocaleId = locale,
+                            MediaLink = reader.GetString(oLink)
+                        });
+                    }
+                }
+            }
+        }
+
+        private async Task SyncBoothMediaAsync(
+            DbConnection conn,
+            DbTransaction tx,
+            int spaceId,
+            int boothId,
+            IReadOnlyList<MediaUpdateDto> mediaItems)
+        {
+            var normalizedItems = mediaItems ?? Array.Empty<MediaUpdateDto>();
+
+            var existing = new Dictionary<string, (string? TextKey, string? DescriptionKey)>(StringComparer.OrdinalIgnoreCase);
+
+            const string fetchSql = @"
+            SELECT bm.media_id, m.text_key, m.description_key
+              FROM booth_media bm
+              INNER JOIN media m ON bm.media_id = m.id
+             WHERE bm.booth_id = @BoothId;";
+
+            await using (var fetchCmd = _db.CreateCommand(conn, fetchSql))
+            {
+                fetchCmd.Transaction = tx;
+                fetchCmd.Parameters.Add(_db.CreateParameter("@BoothId", boothId));
+
+                await using var reader = await fetchCmd.ExecuteReaderAsync();
+                while (await reader.ReadAsync())
+                {
+                    var mediaId = reader.GetString(0);
+                    var textKey = reader.IsDBNull(1) ? null : reader.GetString(1);
+                    var descKey = reader.IsDBNull(2) ? null : reader.GetString(2);
+                    existing[mediaId] = (textKey, descKey);
+                }
+            }
+
+            var requestedIds = new HashSet<string>(normalizedItems
+                .Where(m => !string.IsNullOrWhiteSpace(m.Id))
+                .Select(m => m.Id!), StringComparer.OrdinalIgnoreCase);
+
+            var toDelete = existing.Keys
+                .Where(id => !requestedIds.Contains(id))
+                .ToList();
+
+            foreach (var mediaId in toDelete)
+            {
+                var meta = existing[mediaId];
+                await DeleteMediaCascadeAsync(conn, tx, boothId, mediaId, meta.TextKey, meta.DescriptionKey, spaceId);
+                existing.Remove(mediaId);
+            }
+
+            foreach (var dto in normalizedItems)
+            {
+                if (dto.LinkLocalizations == null || dto.LinkLocalizations.Count == 0)
+                {
+                    continue;
+                }
+
+                if (string.IsNullOrWhiteSpace(dto.Id))
+                {
+                    var createDto = new MediaCreateDto
+                    {
+                        MediaTypeId = dto.MediaTypeId,
+                        TextKey = dto.TextKey,
+                        DescriptionKey = dto.DescriptionKey,
+                        LinkLocalizations = dto.LinkLocalizations,
+                        TextLocalizations = null,
+                        DescriptionLocalizations = null
+                    };
+
+                    var mediaId = await InsertMediaAsync(conn, tx, spaceId, createDto);
+                    await InsertBoothMediaAsync(conn, tx, boothId, mediaId);
+                }
+                else
+                {
+                    var mediaId = dto.Id!;
+
+                    const string updateSql = @"
+                    UPDATE media
+                       SET media_type_id = @MediaTypeId,
+                           text_key = @TextKey,
+                           description_key = @DescKey
+                     WHERE id = @MediaId
+                       AND space_id = @SpaceId;";
+
+                    await using (var cmd = _db.CreateCommand(conn, updateSql))
+                    {
+                        cmd.Transaction = tx;
+                        cmd.Parameters.Add(_db.CreateParameter("@MediaTypeId", dto.MediaTypeId));
+                        cmd.Parameters.Add(_db.CreateParameter("@TextKey", (object?)dto.TextKey ?? DBNull.Value));
+                        cmd.Parameters.Add(_db.CreateParameter("@DescKey", (object?)dto.DescriptionKey ?? DBNull.Value));
+                        cmd.Parameters.Add(_db.CreateParameter("@MediaId", mediaId));
+                        cmd.Parameters.Add(_db.CreateParameter("@SpaceId", spaceId));
+                        await cmd.ExecuteNonQueryAsync();
+                    }
+
+                    await ReplaceMediaLocalizationsAsync(conn, tx, mediaId, dto.LinkLocalizations);
+
+                    if (!existing.ContainsKey(mediaId))
+                    {
+                        await InsertBoothMediaAsync(conn, tx, boothId, mediaId);
+                    }
+                }
+            }
+        }
+
+        private async Task<string> InsertMediaAsync(
+            DbConnection conn,
+            DbTransaction tx,
+            int spaceId,
+            MediaCreateDto dto)
+        {
+            string mediaId;
+            await using (var uuidCmd = _db.CreateCommand(conn, "SELECT UUID();"))
+            {
+                uuidCmd.Transaction = tx;
+                var result = await uuidCmd.ExecuteScalarAsync();
+                mediaId = Convert.ToString(result);
+                if (string.IsNullOrWhiteSpace(mediaId))
+                {
+                    mediaId = Guid.NewGuid().ToString("N");
+                }
+            }
+
+            const string insertMediaSql = @"
+            INSERT INTO media (id, space_id, media_type_id, text_key, description_key)
+            VALUES (@Id, @SpaceId, @MediaTypeId, @TextKey, @DescKey);";
+
+            await using (var cmd = _db.CreateCommand(conn, insertMediaSql))
+            {
+                cmd.Transaction = tx;
+                cmd.Parameters.Add(_db.CreateParameter("@Id", mediaId));
+                cmd.Parameters.Add(_db.CreateParameter("@SpaceId", spaceId));
+                cmd.Parameters.Add(_db.CreateParameter("@MediaTypeId", dto.MediaTypeId));
+                cmd.Parameters.Add(_db.CreateParameter("@TextKey", (object?)dto.TextKey ?? DBNull.Value));
+                cmd.Parameters.Add(_db.CreateParameter("@DescKey", (object?)dto.DescriptionKey ?? DBNull.Value));
+
+                await cmd.ExecuteNonQueryAsync();
+            }
+
+            if (dto.TextKey != null && dto.TextLocalizations != null)
+            {
+                const string insTextSql = @"
+INSERT INTO i18n (`key`, locale_id, value, space_id)
+VALUES (@Key, @LocaleId, @Value, @SpaceId);";
+
+                foreach (var loc in dto.TextLocalizations)
+                {
+                    await using var cmd = _db.CreateCommand(conn, insTextSql);
+                    cmd.Transaction = tx;
+                    cmd.Parameters.Add(_db.CreateParameter("@Key", dto.TextKey));
+                    cmd.Parameters.Add(_db.CreateParameter("@LocaleId", loc.LocaleId));
+                    cmd.Parameters.Add(_db.CreateParameter("@Value", loc.Value ?? string.Empty));
+                    cmd.Parameters.Add(_db.CreateParameter("@SpaceId", spaceId));
+                    await cmd.ExecuteNonQueryAsync();
+                }
+            }
+
+            if (dto.DescriptionKey != null && dto.DescriptionLocalizations != null)
+            {
+                const string insDescSql = @"
+INSERT INTO i18n (`key`, locale_id, value, space_id)
+VALUES (@Key, @LocaleId, @Value, @SpaceId);";
+
+                foreach (var loc in dto.DescriptionLocalizations)
+                {
+                    await using var cmd = _db.CreateCommand(conn, insDescSql);
+                    cmd.Transaction = tx;
+                    cmd.Parameters.Add(_db.CreateParameter("@Key", dto.DescriptionKey));
+                    cmd.Parameters.Add(_db.CreateParameter("@LocaleId", loc.LocaleId));
+                    cmd.Parameters.Add(_db.CreateParameter("@Value", loc.Value ?? string.Empty));
+                    cmd.Parameters.Add(_db.CreateParameter("@SpaceId", spaceId));
+                    await cmd.ExecuteNonQueryAsync();
+                }
+            }
+
+            if (dto.LinkLocalizations != null)
+            {
+                const string insLocSql = @"
+INSERT INTO media_localization (media_id, locale_id, media_link)
+VALUES (@MediaId, @LocaleId, @MediaLink);";
+
+                foreach (var loc in dto.LinkLocalizations)
+                {
+                    await using var cmdLoc = _db.CreateCommand(conn, insLocSql);
+                    cmdLoc.Transaction = tx;
+                    cmdLoc.Parameters.Add(_db.CreateParameter("@MediaId", mediaId));
+                    cmdLoc.Parameters.Add(_db.CreateParameter("@LocaleId", loc.LocaleId));
+                    cmdLoc.Parameters.Add(_db.CreateParameter("@MediaLink", loc.MediaLink));
+                    await cmdLoc.ExecuteNonQueryAsync();
+                }
+            }
+
+            return mediaId;
+        }
+
+        private async Task InsertBoothMediaAsync(DbConnection conn, DbTransaction tx, int boothId, string mediaId)
+        {
+            const string deleteSql = @"
+            DELETE FROM booth_media
+             WHERE booth_id = @BoothId AND media_id = @MediaId;";
+
+            await using (var delCmd = _db.CreateCommand(conn, deleteSql))
+            {
+                delCmd.Transaction = tx;
+                delCmd.Parameters.Add(_db.CreateParameter("@BoothId", boothId));
+                delCmd.Parameters.Add(_db.CreateParameter("@MediaId", mediaId));
+                await delCmd.ExecuteNonQueryAsync();
+            }
+
+            const string insertSql = @"
+            INSERT INTO booth_media (booth_id, media_id)
+            VALUES (@BoothId, @MediaId);";
+
+            await using var insCmd = _db.CreateCommand(conn, insertSql);
+            insCmd.Transaction = tx;
+            insCmd.Parameters.Add(_db.CreateParameter("@BoothId", boothId));
+            insCmd.Parameters.Add(_db.CreateParameter("@MediaId", mediaId));
+            await insCmd.ExecuteNonQueryAsync();
+        }
+
+        private async Task ReplaceMediaLocalizationsAsync(
+            DbConnection conn,
+            DbTransaction tx,
+            string mediaId,
+            IEnumerable<MediaLocalization> localizations)
+        {
+            const string deleteSql = @"
+            DELETE FROM media_localization
+             WHERE media_id = @MediaId;";
+
+            await using (var delCmd = _db.CreateCommand(conn, deleteSql))
+            {
+                delCmd.Transaction = tx;
+                delCmd.Parameters.Add(_db.CreateParameter("@MediaId", mediaId));
+                await delCmd.ExecuteNonQueryAsync();
+            }
+
+            const string insertSql = @"
+            INSERT INTO media_localization (media_id, locale_id, media_link)
+            VALUES (@MediaId, @LocaleId, @MediaLink);";
+
+            foreach (var loc in localizations)
+            {
+                await using var insCmd = _db.CreateCommand(conn, insertSql);
+                insCmd.Transaction = tx;
+                insCmd.Parameters.Add(_db.CreateParameter("@MediaId", mediaId));
+                insCmd.Parameters.Add(_db.CreateParameter("@LocaleId", loc.LocaleId));
+                insCmd.Parameters.Add(_db.CreateParameter("@MediaLink", loc.MediaLink));
+                await insCmd.ExecuteNonQueryAsync();
+            }
+        }
+
+        private async Task DeleteMediaCascadeAsync(
+            DbConnection conn,
+            DbTransaction tx,
+            int boothId,
+            string mediaId,
+            string? textKey,
+            string? descriptionKey,
+            int spaceId)
+        {
+            const string deleteLocSql = @"
+            DELETE FROM media_localization
+             WHERE media_id = @MediaId;";
+
+            await using (var delLoc = _db.CreateCommand(conn, deleteLocSql))
+            {
+                delLoc.Transaction = tx;
+                delLoc.Parameters.Add(_db.CreateParameter("@MediaId", mediaId));
+                await delLoc.ExecuteNonQueryAsync();
+            }
+
+            const string deleteMapSql = @"
+            DELETE FROM booth_media
+             WHERE booth_id = @BoothId AND media_id = @MediaId;";
+
+            await using (var delMap = _db.CreateCommand(conn, deleteMapSql))
+            {
+                delMap.Transaction = tx;
+                delMap.Parameters.Add(_db.CreateParameter("@BoothId", boothId));
+                delMap.Parameters.Add(_db.CreateParameter("@MediaId", mediaId));
+                await delMap.ExecuteNonQueryAsync();
+            }
+
+            const string deleteMediaSql = @"
+            DELETE FROM media
+             WHERE id = @MediaId;";
+
+            await using (var delMedia = _db.CreateCommand(conn, deleteMediaSql))
+            {
+                delMedia.Transaction = tx;
+                delMedia.Parameters.Add(_db.CreateParameter("@MediaId", mediaId));
+                await delMedia.ExecuteNonQueryAsync();
+            }
+
+            if (!string.IsNullOrWhiteSpace(textKey))
+            {
+                const string deleteTextSql = @"
+            DELETE FROM i18n
+             WHERE `key` = @Key AND space_id = @SpaceId;";
+
+                await using var delText = _db.CreateCommand(conn, deleteTextSql);
+                delText.Transaction = tx;
+                delText.Parameters.Add(_db.CreateParameter("@Key", textKey));
+                delText.Parameters.Add(_db.CreateParameter("@SpaceId", spaceId));
+                await delText.ExecuteNonQueryAsync();
+            }
+
+            if (!string.IsNullOrWhiteSpace(descriptionKey))
+            {
+                const string deleteDescSql = @"
+            DELETE FROM i18n
+             WHERE `key` = @Key AND space_id = @SpaceId;";
+
+                await using var delDesc = _db.CreateCommand(conn, deleteDescSql);
+                delDesc.Transaction = tx;
+                delDesc.Parameters.Add(_db.CreateParameter("@Key", descriptionKey));
+                delDesc.Parameters.Add(_db.CreateParameter("@SpaceId", spaceId));
+                await delDesc.ExecuteNonQueryAsync();
+            }
+        }
+
+        private static List<MediaCreateDto> NormalizeMediaCreates(List<MediaCreateDto>? mediaItems, HashSet<string> supportedLocales)
+        {
+            var result = new List<MediaCreateDto>();
+            if (mediaItems == null)
+                return result;
+
+            foreach (var item in mediaItems)
+            {
+                if (item == null)
+                    continue;
+
+                var links = NormalizeLocalizations(item.LinkLocalizations, supportedLocales);
+                if (links.Count == 0)
+                    continue;
+
+                result.Add(new MediaCreateDto
+                {
+                    MediaTypeId = item.MediaTypeId,
+                    TextKey = item.TextKey,
+                    DescriptionKey = item.DescriptionKey,
+                    LinkLocalizations = links,
+                    TextLocalizations = NormalizeLocalizedValues(item.TextLocalizations, supportedLocales),
+                    DescriptionLocalizations = NormalizeLocalizedValues(item.DescriptionLocalizations, supportedLocales)
+                });
+            }
+
+            return result;
+        }
+
+        private static List<MediaUpdateDto> NormalizeMediaUpdates(List<MediaUpdateDto>? mediaItems, HashSet<string> supportedLocales)
+        {
+            var result = new List<MediaUpdateDto>();
+            if (mediaItems == null)
+                return result;
+
+            foreach (var item in mediaItems)
+            {
+                if (item == null)
+                    continue;
+
+                var links = NormalizeLocalizations(item.LinkLocalizations, supportedLocales);
+                if (links.Count == 0)
+                    continue;
+
+                result.Add(new MediaUpdateDto
+                {
+                    Id = item.Id,
+                    MediaTypeId = item.MediaTypeId,
+                    TextKey = item.TextKey,
+                    DescriptionKey = item.DescriptionKey,
+                    LinkLocalizations = links
+                });
+            }
+
+            return result;
+        }
+
+        private static List<MediaLocalization> NormalizeLocalizations(IEnumerable<MediaLocalization>? source, HashSet<string> supportedLocales)
+        {
+            var result = new List<MediaLocalization>();
+            if (source == null)
+                return result;
+
+            foreach (var loc in source)
+            {
+                if (loc == null)
+                    continue;
+
+                if (string.IsNullOrWhiteSpace(loc.LocaleId))
+                    continue;
+
+                if (!supportedLocales.Contains(loc.LocaleId))
+                    continue;
+
+                if (result.Any(l => string.Equals(l.LocaleId, loc.LocaleId, StringComparison.OrdinalIgnoreCase)))
+                    continue;
+
+                result.Add(new MediaLocalization
+                {
+                    LocaleId = loc.LocaleId,
+                    MediaLink = loc.MediaLink
+                });
+            }
+
+            return result;
+        }
+
+        private static List<LocalizedValue>? NormalizeLocalizedValues(IEnumerable<LocalizedValue>? source, HashSet<string> supportedLocales)
+        {
+            if (source == null)
+                return null;
+
+            var result = new List<LocalizedValue>();
+
+            foreach (var loc in source)
+            {
+                if (loc == null)
+                    continue;
+
+                if (string.IsNullOrWhiteSpace(loc.LocaleId))
+                    continue;
+
+                if (!supportedLocales.Contains(loc.LocaleId))
+                    continue;
+
+                if (result.Any(l => string.Equals(l.LocaleId, loc.LocaleId, StringComparison.OrdinalIgnoreCase)))
+                    continue;
+
+                result.Add(new LocalizedValue
+                {
+                    LocaleId = loc.LocaleId,
+                    Value = loc.Value
+                });
+            }
+
+            return result;
         }
         //===The following function is an example of how an AppLogger logging can be implemented in the method===
         /*public async Task<List<BoothModel>> GetAllBoothsBySpaceAsync(int spaceId)
@@ -303,20 +846,35 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
                 var allLocales = dto.LocalizedPairs?.Values?
                     .Select(v => v.LocaleId)
                     .Where(s => !string.IsNullOrWhiteSpace(s))
-                    .Distinct(StringComparer.OrdinalIgnoreCase)
                     .ToList() ?? new List<string>();
 
+                if (dto.MediaItems != null)
+                {
+                    foreach (var locale in dto.MediaItems
+                        .Where(m => m?.LinkLocalizations != null)
+                        .SelectMany(m => m.LinkLocalizations!)
+                        .Select(l => l.LocaleId)
+                        .Where(s => !string.IsNullOrWhiteSpace(s)))
+                    {
+                        allLocales.Add(locale);
+                    }
+                }
+
+                allLocales = allLocales
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToList();
+
+                var supported = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
                 if (allLocales.Count > 0)
                 {
                     const string checkSupportedLangSqlBase = @"
-                    SELECT locale_id 
-                      FROM supported_languages 
+                    SELECT locale_id
+                      FROM supported_languages
                      WHERE locale_id IN ({0}) AND space_id = @SpaceId;";
 
                     var paramNames = allLocales.Select((_, i) => $"@loc{i}").ToList();
                     var dynamicQuery = string.Format(checkSupportedLangSqlBase, string.Join(", ", paramNames));
 
-                    var supported = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
                     await using (var checkCmd = _db.CreateCommand(conn, dynamicQuery))
                     {
                         checkCmd.Transaction = tx;
@@ -333,6 +891,8 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
                     if (unsupported.Count > 0)
                         throw new InvalidOperationException($"Unsupported locales: {string.Join(", ", unsupported)}");
                 }
+
+                var normalizedMedia = NormalizeMediaUpdates(dto.MediaItems, supported);
 
                 // 4) Upsert i18n for booth name_key
                 const string updI18n = @"
@@ -366,6 +926,8 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
                         }
                     }
                 }
+
+                await SyncBoothMediaAsync(conn, tx, spaceId, boothId, normalizedMedia);
 
                 await tx.CommitAsync();
 
@@ -445,7 +1007,8 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
                     {
                         Key = reader.GetString(o_name_key),
                         Values = values
-                    }
+                    },
+                    MediaItems = new List<MediaData>()
                 };
 
                 // accumulate locales
@@ -458,6 +1021,16 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
                         Value = reader.GetString(o_value)
                     });
                 }
+            }
+
+            if (booth is not null)
+            {
+                var map = new Dictionary<int, BoothModel>
+                {
+                    [booth.Id] = booth
+                };
+
+                await LoadBoothMediaAsync(conn, map, spaceId);
             }
 
             return booth;
@@ -523,6 +1096,21 @@ VALUES (@SpaceId, @NameKey, @MapSpotId);";
                 var allLocales = values
                     .Select(v => v.LocaleId)
                     .Where(s => !string.IsNullOrWhiteSpace(s))
+                    .ToList();
+
+                if (boothDto.MediaItems != null)
+                {
+                    foreach (var locale in boothDto.MediaItems
+                        .Where(m => m?.LinkLocalizations != null)
+                        .SelectMany(m => m.LinkLocalizations!)
+                        .Select(l => l.LocaleId)
+                        .Where(s => !string.IsNullOrWhiteSpace(s)))
+                    {
+                        allLocales.Add(locale);
+                    }
+                }
+
+                allLocales = allLocales
                     .Distinct(StringComparer.OrdinalIgnoreCase)
                     .ToList();
 
@@ -565,7 +1153,31 @@ VALUES (@NameKey, @LocaleId, @Value, @SpaceId);";
                     cmdI18n.Parameters.Add(_db.CreateParameter("@SpaceId", spaceId));
                     await cmdI18n.ExecuteNonQueryAsync();
 
-                    insertedValues.Add(new LocalizedValue { LocaleId = val.LocaleId, Value = val.Value });
+                        insertedValues.Add(new LocalizedValue { LocaleId = val.LocaleId, Value = val.Value });
+                }
+
+                var normalizedMedia = NormalizeMediaCreates(boothDto.MediaItems, supported);
+                var insertedMedia = new List<MediaData>();
+
+                foreach (var mediaDto in normalizedMedia)
+                {
+                    var mediaId = await InsertMediaAsync(conn, tx, spaceId, mediaDto);
+                    await InsertBoothMediaAsync(conn, tx, newBoothId, mediaId);
+
+                    insertedMedia.Add(new MediaData
+                    {
+                        Id = mediaId,
+                        MediaTypeId = mediaDto.MediaTypeId,
+                        TextKey = mediaDto.TextKey,
+                        DescriptionKey = mediaDto.DescriptionKey,
+                        LinkLocalizations = mediaDto.LinkLocalizations?
+                            .Select(l => new MediaLocalization
+                            {
+                                LocaleId = l.LocaleId,
+                                MediaLink = l.MediaLink
+                            })
+                            .ToList() ?? new List<MediaLocalization>()
+                    });
                 }
 
                 await tx.CommitAsync();
@@ -580,7 +1192,8 @@ VALUES (@NameKey, @LocaleId, @Value, @SpaceId);";
                     {
                         Key = boothDto.LocalizedPairs.Key,
                         Values = insertedValues
-                    }
+                    },
+                    MediaItems = insertedMedia
                 };
             }
             catch
@@ -621,6 +1234,29 @@ VALUES (@NameKey, @LocaleId, @Value, @SpaceId);";
                         return false;
                     }
                     boothKey = Convert.ToString(o);
+                }
+
+                var boothMedia = new List<(string MediaId, string? TextKey, string? DescriptionKey)>();
+                const string fetchBoothMediaSql = @"
+            SELECT bm.media_id, m.text_key, m.description_key
+              FROM booth_media bm
+              INNER JOIN media m ON bm.media_id = m.id
+             WHERE bm.booth_id = @BoothId;";
+
+                await using (var mediaCmd = _db.CreateCommand(conn, fetchBoothMediaSql))
+                {
+                    mediaCmd.Transaction = tx;
+                    mediaCmd.Parameters.Add(_db.CreateParameter("@BoothId", boothId));
+
+                    await using var mediaReader = await mediaCmd.ExecuteReaderAsync();
+                    while (await mediaReader.ReadAsync())
+                    {
+                        boothMedia.Add((
+                            mediaReader.GetString(0),
+                            mediaReader.IsDBNull(1) ? null : mediaReader.GetString(1),
+                            mediaReader.IsDBNull(2) ? null : mediaReader.GetString(2)
+                        ));
+                    }
                 }
 
                 // 2) Fetch portals for this booth
@@ -721,6 +1357,11 @@ VALUES (@NameKey, @LocaleId, @Value, @SpaceId);";
                             await cmd.ExecuteNonQueryAsync();
                         }
                     }
+                }
+
+                foreach (var media in boothMedia)
+                {
+                    await DeleteMediaCascadeAsync(conn, tx, boothId, media.MediaId, media.TextKey, media.DescriptionKey, spaceId);
                 }
 
                 // 5) Delete booth's i18n & booth

--- a/TifoXRCoreWebAPI.Tests/Repositories/BoothRepositoryTests.cs
+++ b/TifoXRCoreWebAPI.Tests/Repositories/BoothRepositoryTests.cs
@@ -80,9 +80,40 @@ namespace GMS.TifoXRCoreWebAPI.Tests.Repositories
                 })
                 .Build();
 
+        private static DbDataReader BoothMediaRows(params (int boothId, string mediaId, int mediaTypeId, string? textKey, string? descriptionKey, string? localeId, string? mediaLink)[] rows)
+        {
+            var t = new DataTable();
+            t.Columns.Add("booth_id", typeof(int));
+            t.Columns.Add("media_id", typeof(string));
+            t.Columns.Add("media_type_id", typeof(int));
+            t.Columns.Add("text_key", typeof(string));
+            t.Columns.Add("description_key", typeof(string));
+            t.Columns.Add("locale_id", typeof(string));
+            t.Columns.Add("media_link", typeof(string));
+
+            foreach (var row in rows)
+            {
+                t.Rows.Add(
+                    row.boothId,
+                    row.mediaId,
+                    row.mediaTypeId,
+                    row.textKey is null ? (object)DBNull.Value : row.textKey,
+                    row.descriptionKey is null ? (object)DBNull.Value : row.descriptionKey,
+                    row.localeId is null ? (object)DBNull.Value : row.localeId,
+                    row.mediaLink is null ? (object)DBNull.Value : row.mediaLink
+                );
+            }
+
+            return t.CreateDataReader();
+        }
+
+        private static DbDataReader BoothMediaEmpty() => BoothMediaRows();
+
         private static BoothRepository MakeSut(DataTable dt)
         {
-            IDbProvider fakeDb = new FakeDbProvider(() => dt.CreateDataReader());
+            var fakeDb = new FakeDbProvider(() => throw new InvalidOperationException("unexpected fallback reader"));
+            fakeDb.EnqueueReader(() => dt.CreateDataReader());
+            fakeDb.EnqueueReader(BoothMediaEmpty);
             return new BoothRepository(MakeConfig(), fakeDb);
         }
         private static BoothCreateDto CreateDto(int spotId, string key, params (string loc, string val)[] pairs)
@@ -315,6 +346,31 @@ namespace GMS.TifoXRCoreWebAPI.Tests.Repositories
             booth.LocalizedPairs.Values.Should().Contain(v => v.LocaleId == "fr_fr" && v.Value == "Texte");
         }
 
+        [Fact]
+        public async Task IncludesMediaLinks()
+        {
+            var dt = BoothGetSchema.CreateEmptySchema();
+            dt.Rows.Add(10, 55, "bth_key", DBNull.Value, DBNull.Value, DBNull.Value, DBNull.Value, "en_us", "Booth EN");
+
+            var fake = new FakeDbProvider(() => throw new InvalidOperationException("unexpected fallback"));
+            fake.EnqueueReader(() => dt.CreateDataReader());
+            fake.EnqueueReader(() => BoothMediaRows(
+                (10, "media123", 7, null, null, "en_us", "https://cdn/en"),
+                (10, "media123", 7, null, null, "es_es", "https://cdn/es")
+            ));
+
+            var sut = new BoothRepository(MakeConfig(), fake);
+
+            var result = await sut.GetAllBoothsBySpaceAsync(55);
+
+            var booth = result.Should().ContainSingle().Subject;
+            booth.MediaItems.Should().HaveCount(1);
+            booth.MediaItems[0].Id.Should().Be("media123");
+            booth.MediaItems[0].MediaTypeId.Should().Be(7);
+            booth.MediaItems[0].LinkLocalizations.Select(l => l.LocaleId)
+                .Should().BeEquivalentTo(new[] { "en_us", "es_es" });
+        }
+
         /// <summary>COUNT(map_spot)=0 -> throws.</summary>
         [Fact]
         public async Task MapSpotMissingThrows()
@@ -370,11 +426,13 @@ namespace GMS.TifoXRCoreWebAPI.Tests.Repositories
             fake.EnqueueNonQuery(0);               // upd en_us -> 0
             fake.EnqueueNonQuery(1);               // ins en_us -> 1
             fake.EnqueueNonQuery(1);               // upd es_es -> 1
+            fake.EnqueueReader(BoothMediaEmpty);   // existing booth_media
             fake.EnqueueReader(() => ReloadRows(   // reload
                 id: 10, spaceId: 1, key: "bth_key", mapSpotId: 5,
                 x: 1.1m, y: 2.2m, z: 3.3m,
                 ("en_us", "Hello"), ("es_es", "Hola")
             ));
+            fake.EnqueueReader(BoothMediaEmpty);   // reload media
 
             var sut = new BoothRepository(MakeConfig(), fake);
             var dto = Dto(5, "bth_key", ("en_us", "Hello"), ("es_es", "Hola"));
@@ -402,11 +460,13 @@ namespace GMS.TifoXRCoreWebAPI.Tests.Repositories
 
             fake.EnqueueScalar(1); // spot ok
             fake.EnqueueNonQuery(1); // update booth
+            fake.EnqueueReader(BoothMediaEmpty); // existing booth_media
             fake.EnqueueReader(() => ReloadRows(
                 id: 22, spaceId: 3, key: "bth_key", mapSpotId: 7,
                 x: 9.9m, y: 8.8m, z: 7.7m,
                 ("en_us", "Existing From DB")
             ));
+            fake.EnqueueReader(BoothMediaEmpty); // reload media
 
             var sut = new BoothRepository(MakeConfig(), fake);
             var res = await sut.UpdateBoothAsync(3, 22, dto);
@@ -417,6 +477,63 @@ namespace GMS.TifoXRCoreWebAPI.Tests.Repositories
             res.MapSpotId.Should().Be(7);
             res.MapSpot!.X.Should().Be(9.9m);
             res.LocalizedPairs.Values.Should().ContainSingle(v => v.LocaleId == "en_us" && v.Value == "Existing From DB");
+        }
+
+        [Fact]
+        public async Task UpdateAddsNewMedia()
+        {
+            var fake = new FakeDbProvider(() => throw new InvalidOperationException("unexpected fallback"));
+            var dto = new BoothUpdateDto
+            {
+                MapSpotId = 9,
+                LocalizedPairs = new LocalizedPairs
+                {
+                    Key = "bth_key",
+                    Values = new List<LocalizedValue>
+                    {
+                        new() { LocaleId = "en_us", Value = "Name" }
+                    }
+                },
+                MediaItems = new List<MediaUpdateDto>
+                {
+                    new()
+                    {
+                        MediaTypeId = 4,
+                        LinkLocalizations = new List<MediaLocalization>
+                        {
+                            new() { LocaleId = "en_us", MediaLink = "https://cdn/en" }
+                        }
+                    }
+                }
+            };
+
+            fake.EnqueueScalar(1); // map spot ok
+            fake.EnqueueNonQuery(1); // update booth
+            fake.EnqueueReader(() => Langs("en_us")); // supported locales
+            fake.EnqueueNonQuery(0); // update i18n -> 0 rows
+            fake.EnqueueNonQuery(1); // insert i18n
+            fake.EnqueueReader(BoothMediaEmpty); // fetch existing booth media
+            fake.EnqueueScalar("media-new"); // SELECT UUID()
+            fake.EnqueueNonQuery(1); // insert media row
+            fake.EnqueueNonQuery(1); // insert media localization
+            fake.EnqueueNonQuery(1); // delete existing booth_media mapping (none)
+            fake.EnqueueNonQuery(1); // insert booth_media mapping
+            fake.EnqueueReader(() => ReloadRows(
+                id: 33, spaceId: 2, key: "bth_key", mapSpotId: 9,
+                x: 0m, y: 0m, z: 0m,
+                ("en_us", "Name")
+            ));
+            fake.EnqueueReader(() => BoothMediaRows(
+                (33, "media-new", 4, null, null, "en_us", "https://cdn/en")
+            ));
+
+            var sut = new BoothRepository(MakeConfig(), fake);
+            var result = await sut.UpdateBoothAsync(2, 33, dto);
+
+            result.Should().NotBeNull();
+            result!.MediaItems.Should().ContainSingle(m => m.Id == "media-new");
+            result.MediaItems[0].LinkLocalizations.Should()
+                .ContainSingle(l => l.LocaleId == "en_us" && l.MediaLink == "https://cdn/en");
         }
 
 
@@ -617,6 +734,8 @@ namespace GMS.TifoXRCoreWebAPI.Tests.Repositories
             var fake = new FakeDbProvider(() => throw new InvalidOperationException("unexpected fallback"));
             // 1) fetch booth name_key
             fake.EnqueueScalar("bth_key");
+            // 2) fetch booth media -> none
+            fake.EnqueueReader(BoothMediaEmpty);
             // 2) fetch portals -> none
             fake.EnqueueReader(() => PortalRows());
             // 5) delete booth i18n + booth
@@ -636,6 +755,8 @@ namespace GMS.TifoXRCoreWebAPI.Tests.Repositories
             var fake = new FakeDbProvider(() => throw new InvalidOperationException("unexpected fallback"));
             // 1) booth key
             fake.EnqueueScalar("bth_key");
+            // 2) booth media -> none
+            fake.EnqueueReader(BoothMediaEmpty);
             // 2) portals: p1(c1, null), p2(null, t2), p3(c3, t3)
             fake.EnqueueReader(() => PortalRows(
                 (1, "p1_key", "c1", null),
@@ -677,6 +798,8 @@ namespace GMS.TifoXRCoreWebAPI.Tests.Repositories
             var fake = new FakeDbProvider(() => throw new InvalidOperationException("unexpected fallback"));
             // 1) booth key
             fake.EnqueueScalar("bth_key");
+            // 2) booth media -> none
+            fake.EnqueueReader(BoothMediaEmpty);
             // 2) one portal with whitespace corr/thumb → should NOT trigger media deletes
             fake.EnqueueReader(() => PortalRows(
                 (5, "p5_key", "   ", " \t ")
@@ -691,6 +814,29 @@ namespace GMS.TifoXRCoreWebAPI.Tests.Repositories
 
             var sut = new BoothRepository(MakeConfig(), fake);
             var ok = await sut.DeleteBoothCascadeAsync(2, 5);
+
+            ok.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task DeleteRemovesBoothMedia()
+        {
+            var fake = new FakeDbProvider(() => throw new InvalidOperationException("unexpected fallback"));
+            fake.EnqueueScalar("bth_key");
+            fake.EnqueueReader(() => BoothMediaRows(
+                (10, "mediaX", 4, "text_key", "desc_key", "en_us", "https://media")
+            ));
+            fake.EnqueueReader(() => PortalRows());
+            fake.EnqueueNonQuery(1); // del media_localization
+            fake.EnqueueNonQuery(1); // del booth_media
+            fake.EnqueueNonQuery(1); // del media
+            fake.EnqueueNonQuery(1); // del text i18n
+            fake.EnqueueNonQuery(1); // del desc i18n
+            fake.EnqueueNonQuery(1); // del booth i18n
+            fake.EnqueueNonQuery(1); // del booth
+
+            var sut = new BoothRepository(MakeConfig(), fake);
+            var ok = await sut.DeleteBoothCascadeAsync(1, 10);
 
             ok.Should().BeTrue();
         }


### PR DESCRIPTION
## Summary
- extend booth models and DTOs to include optional media collections
- load booth media when querying booths and manage media persistence during create, update, and delete operations
- expand repository tests to cover booth media scenarios and new cascade behavior

## Testing
- `dotnet test` *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e7bc6d19808329ba1f3182eda81ca2