### PR TITLE
Refine booth update contract and add media endpoint

### DIFF
--- a/Controllers/BoothController.cs
+++ b/Controllers/BoothController.cs
@@ -195,6 +195,59 @@ namespace GMS.TifoXRCoreWebAPI.Controllers
             );
         }
 
+        /// <summary>
+        /// POST /api/space/{spaceId}/booth/{boothId}/media
+        /// Adds a new media item to the specified booth.
+        /// </summary>
+        [HttpPost("{spaceId}/booth/{boothId}/media")]
+        [ProducesResponseType(typeof(MediaData), StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+        public async Task<ActionResult<MediaData>> AddMediaToBooth(
+            [FromRoute] int spaceId,
+            [FromRoute] int boothId,
+            [FromBody] MediaCreateDto mediaDto)
+        {
+            if (spaceId <= 0)
+                throw ErrorService.Exception(
+                    ErrorType.Argument,
+                    nameof(AddMediaToBooth),
+                    ErrorMessages.Validation.PositiveIntRequired,
+                    paramName: nameof(spaceId),
+                    parameters: new { spaceId, boothId });
+
+            if (boothId <= 0)
+                throw ErrorService.Exception(
+                    ErrorType.Argument,
+                    nameof(AddMediaToBooth),
+                    ErrorMessages.Validation.PositiveIntRequired,
+                    paramName: nameof(boothId),
+                    parameters: new { spaceId, boothId });
+
+            if (mediaDto is null)
+                throw ErrorService.Exception(
+                    ErrorType.ArgumentNull,
+                    nameof(AddMediaToBooth),
+                    ErrorMessages.Validation.MissingParameter,
+                    paramName: nameof(mediaDto),
+                    parameters: new { spaceId, boothId });
+
+            var created = await _boothRepository.AddMediaToBoothAsync(spaceId, boothId, mediaDto);
+
+            if (created is null)
+                throw ErrorService.Exception(
+                    ErrorType.NotFound,
+                    nameof(AddMediaToBooth),
+                    ErrorMessages.Http.NotFound,
+                    parameters: new { spaceId, boothId });
+
+            return CreatedAtAction(
+                nameof(GetAllBoothsBySpace),
+                new { spaceId },
+                created);
+        }
+
         #endregion
 
         #region DELETE

--- a/Models/BoothModel.cs
+++ b/Models/BoothModel.cs
@@ -42,14 +42,24 @@ namespace GMS.TifoXRCoreWebAPI.Models
     }
 
 
+    public class BoothLocalizedPairsUpdateDto
+    {
+        public List<LocalizedValue>? Values { get; set; }
+    }
+
+    public class BoothMediaUpdateDto
+    {
+        public int MediaTypeId { get; set; }
+        public string? TextKey { get; set; }
+        public string? DescriptionKey { get; set; }
+        public List<MediaLocalization>? LinkLocalizations { get; set; }
+    }
+
     public class BoothUpdateDto
     {
-        public LocalizedPairs LocalizedPairs { get; set; }
+        public BoothLocalizedPairsUpdateDto? LocalizedPairs { get; set; }
         public int MapSpotId { get; set; }
-
-        public MapSpotModel MapSpot { get; set; }
-
-        public List<MediaUpdateDto>? MediaItems { get; set; }
+        public List<BoothMediaUpdateDto>? MediaItems { get; set; }
 
     }
 

--- a/Repositories/BoothRepository.cs
+++ b/Repositories/BoothRepository.cs
@@ -233,17 +233,21 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
             DbTransaction tx,
             int spaceId,
             int boothId,
-            IReadOnlyList<MediaUpdateDto> mediaItems)
+            IReadOnlyList<BoothMediaUpdateDto> mediaItems)
         {
-            var normalizedItems = mediaItems ?? Array.Empty<MediaUpdateDto>();
+            var normalizedItems = mediaItems ?? Array.Empty<BoothMediaUpdateDto>();
 
-            var existing = new Dictionary<string, (string? TextKey, string? DescriptionKey)>(StringComparer.OrdinalIgnoreCase);
+            if (normalizedItems.Count == 0)
+                return;
+
+            var existing = new List<(string MediaId, string? TextKey, string? DescriptionKey)>();
 
             const string fetchSql = @"
             SELECT bm.media_id, m.text_key, m.description_key
               FROM booth_media bm
               INNER JOIN media m ON bm.media_id = m.id
-             WHERE bm.booth_id = @BoothId;";
+             WHERE bm.booth_id = @BoothId
+             ORDER BY bm.media_id;";
 
             await using (var fetchCmd = _db.CreateCommand(conn, fetchSql))
             {
@@ -253,80 +257,108 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
                 await using var reader = await fetchCmd.ExecuteReaderAsync();
                 while (await reader.ReadAsync())
                 {
-                    var mediaId = reader.GetString(0);
-                    var textKey = reader.IsDBNull(1) ? null : reader.GetString(1);
-                    var descKey = reader.IsDBNull(2) ? null : reader.GetString(2);
-                    existing[mediaId] = (textKey, descKey);
+                    existing.Add((
+                        reader.GetString(0),
+                        reader.IsDBNull(1) ? null : reader.GetString(1),
+                        reader.IsDBNull(2) ? null : reader.GetString(2)));
                 }
             }
 
-            var requestedIds = new HashSet<string>(normalizedItems
-                .Where(m => !string.IsNullOrWhiteSpace(m.Id))
-                .Select(m => m.Id!), StringComparer.OrdinalIgnoreCase);
+            if (existing.Count == 0)
+                throw new InvalidOperationException("No media exists for this booth to update.");
 
-            var toDelete = existing.Keys
-                .Where(id => !requestedIds.Contains(id))
-                .ToList();
+            if (normalizedItems.Count > existing.Count)
+                throw new InvalidOperationException("Cannot add new media via booth update. Use the media creation endpoint instead.");
 
-            foreach (var mediaId in toDelete)
-            {
-                var meta = existing[mediaId];
-                await DeleteMediaCascadeAsync(conn, tx, boothId, mediaId, meta.TextKey, meta.DescriptionKey, spaceId);
-                existing.Remove(mediaId);
-            }
+            var usedIndexes = new HashSet<int>();
 
             foreach (var dto in normalizedItems)
             {
                 if (dto.LinkLocalizations == null || dto.LinkLocalizations.Count == 0)
-                {
                     continue;
-                }
 
-                if (string.IsNullOrWhiteSpace(dto.Id))
+                var index = FindMatchingMediaIndex(dto, existing, usedIndexes);
+                if (index < 0)
+                    throw new InvalidOperationException("Unable to match media update request to existing booth media.");
+
+                usedIndexes.Add(index);
+                var mediaMeta = existing[index];
+
+                const string updateSql = @"
+                UPDATE media
+                   SET media_type_id = @MediaTypeId,
+                       text_key = @TextKey,
+                       description_key = @DescKey
+                 WHERE id = @MediaId
+                   AND space_id = @SpaceId;";
+
+                await using (var cmd = _db.CreateCommand(conn, updateSql))
                 {
-                    var createDto = new MediaCreateDto
-                    {
-                        MediaTypeId = dto.MediaTypeId,
-                        TextKey = dto.TextKey,
-                        DescriptionKey = dto.DescriptionKey,
-                        LinkLocalizations = dto.LinkLocalizations,
-                        TextLocalizations = null,
-                        DescriptionLocalizations = null
-                    };
-
-                    var mediaId = await InsertMediaAsync(conn, tx, spaceId, createDto);
-                    await InsertBoothMediaAsync(conn, tx, boothId, mediaId);
+                    cmd.Transaction = tx;
+                    cmd.Parameters.Add(_db.CreateParameter("@MediaTypeId", dto.MediaTypeId));
+                    cmd.Parameters.Add(_db.CreateParameter("@TextKey", (object?)dto.TextKey ?? DBNull.Value));
+                    cmd.Parameters.Add(_db.CreateParameter("@DescKey", (object?)dto.DescriptionKey ?? DBNull.Value));
+                    cmd.Parameters.Add(_db.CreateParameter("@MediaId", mediaMeta.MediaId));
+                    cmd.Parameters.Add(_db.CreateParameter("@SpaceId", spaceId));
+                    await cmd.ExecuteNonQueryAsync();
                 }
-                else
+
+                await ReplaceMediaLocalizationsAsync(conn, tx, mediaMeta.MediaId, dto.LinkLocalizations);
+            }
+
+            static int FindMatchingMediaIndex(
+                BoothMediaUpdateDto dto,
+                List<(string MediaId, string? TextKey, string? DescriptionKey)> existing,
+                HashSet<int> usedIndexes)
+            {
+                bool MatchEntry(int idx, Func<(string MediaId, string? TextKey, string? DescriptionKey), bool> predicate)
+                    => !usedIndexes.Contains(idx) && predicate(existing[idx]);
+
+                string? textKey = dto.TextKey;
+                string? descKey = dto.DescriptionKey;
+
+                // 1) Match on both text & description keys when provided.
+                if (!string.IsNullOrWhiteSpace(textKey) || !string.IsNullOrWhiteSpace(descKey))
                 {
-                    var mediaId = dto.Id!;
-
-                    const string updateSql = @"
-                    UPDATE media
-                       SET media_type_id = @MediaTypeId,
-                           text_key = @TextKey,
-                           description_key = @DescKey
-                     WHERE id = @MediaId
-                       AND space_id = @SpaceId;";
-
-                    await using (var cmd = _db.CreateCommand(conn, updateSql))
+                    for (var i = 0; i < existing.Count; i++)
                     {
-                        cmd.Transaction = tx;
-                        cmd.Parameters.Add(_db.CreateParameter("@MediaTypeId", dto.MediaTypeId));
-                        cmd.Parameters.Add(_db.CreateParameter("@TextKey", (object?)dto.TextKey ?? DBNull.Value));
-                        cmd.Parameters.Add(_db.CreateParameter("@DescKey", (object?)dto.DescriptionKey ?? DBNull.Value));
-                        cmd.Parameters.Add(_db.CreateParameter("@MediaId", mediaId));
-                        cmd.Parameters.Add(_db.CreateParameter("@SpaceId", spaceId));
-                        await cmd.ExecuteNonQueryAsync();
-                    }
-
-                    await ReplaceMediaLocalizationsAsync(conn, tx, mediaId, dto.LinkLocalizations);
-
-                    if (!existing.ContainsKey(mediaId))
-                    {
-                        await InsertBoothMediaAsync(conn, tx, boothId, mediaId);
+                        if (MatchEntry(i, e =>
+                                string.Equals(e.TextKey, textKey, StringComparison.OrdinalIgnoreCase) &&
+                                string.Equals(e.DescriptionKey, descKey, StringComparison.OrdinalIgnoreCase)))
+                        {
+                            return i;
+                        }
                     }
                 }
+
+                // 2) Match on text key alone.
+                if (!string.IsNullOrWhiteSpace(textKey))
+                {
+                    for (var i = 0; i < existing.Count; i++)
+                    {
+                        if (MatchEntry(i, e => string.Equals(e.TextKey, textKey, StringComparison.OrdinalIgnoreCase)))
+                            return i;
+                    }
+                }
+
+                // 3) Match on description key alone.
+                if (!string.IsNullOrWhiteSpace(descKey))
+                {
+                    for (var i = 0; i < existing.Count; i++)
+                    {
+                        if (MatchEntry(i, e => string.Equals(e.DescriptionKey, descKey, StringComparison.OrdinalIgnoreCase)))
+                            return i;
+                    }
+                }
+
+                // 4) Fallback to the first unused entry (preserve order).
+                for (var i = 0; i < existing.Count; i++)
+                {
+                    if (!usedIndexes.Contains(i))
+                        return i;
+                }
+
+                return -1;
             }
         }
 
@@ -570,34 +602,6 @@ VALUES (@MediaId, @LocaleId, @MediaLink);";
                     LinkLocalizations = links,
                     TextLocalizations = NormalizeLocalizedValues(item.TextLocalizations, supportedLocales),
                     DescriptionLocalizations = NormalizeLocalizedValues(item.DescriptionLocalizations, supportedLocales)
-                });
-            }
-
-            return result;
-        }
-
-        private static List<MediaUpdateDto> NormalizeMediaUpdates(List<MediaUpdateDto>? mediaItems, HashSet<string> supportedLocales)
-        {
-            var result = new List<MediaUpdateDto>();
-            if (mediaItems == null)
-                return result;
-
-            foreach (var item in mediaItems)
-            {
-                if (item == null)
-                    continue;
-
-                var links = NormalizeLocalizations(item.LinkLocalizations, supportedLocales);
-                if (links.Count == 0)
-                    continue;
-
-                result.Add(new MediaUpdateDto
-                {
-                    Id = item.Id,
-                    MediaTypeId = item.MediaTypeId,
-                    TextKey = item.TextKey,
-                    DescriptionKey = item.DescriptionKey,
-                    LinkLocalizations = links
                 });
             }
 
@@ -762,107 +766,6 @@ VALUES (@MediaId, @LocaleId, @MediaLink);";
             }
         }
 
-        private async Task SyncBoothMediaAsync(
-            DbConnection conn,
-            DbTransaction tx,
-            int spaceId,
-            int boothId,
-            IReadOnlyList<MediaUpdateDto> mediaItems)
-        {
-            var normalizedItems = mediaItems ?? Array.Empty<MediaUpdateDto>();
-
-            var existing = new Dictionary<string, (string? TextKey, string? DescriptionKey)>(StringComparer.OrdinalIgnoreCase);
-
-            const string fetchSql = @"
-            SELECT bm.media_id, m.text_key, m.description_key
-              FROM booth_media bm
-              INNER JOIN media m ON bm.media_id = m.id
-             WHERE bm.booth_id = @BoothId;";
-
-            await using (var fetchCmd = _db.CreateCommand(conn, fetchSql))
-            {
-                fetchCmd.Transaction = tx;
-                fetchCmd.Parameters.Add(_db.CreateParameter("@BoothId", boothId));
-
-                await using var reader = await fetchCmd.ExecuteReaderAsync();
-                while (await reader.ReadAsync())
-                {
-                    var mediaId = reader.GetString(0);
-                    var textKey = reader.IsDBNull(1) ? null : reader.GetString(1);
-                    var descKey = reader.IsDBNull(2) ? null : reader.GetString(2);
-                    existing[mediaId] = (textKey, descKey);
-                }
-            }
-
-            var requestedIds = new HashSet<string>(normalizedItems
-                .Where(m => !string.IsNullOrWhiteSpace(m.Id))
-                .Select(m => m.Id!), StringComparer.OrdinalIgnoreCase);
-
-            var toDelete = existing.Keys
-                .Where(id => !requestedIds.Contains(id))
-                .ToList();
-
-            foreach (var mediaId in toDelete)
-            {
-                var meta = existing[mediaId];
-                await DeleteMediaCascadeAsync(conn, tx, boothId, mediaId, meta.TextKey, meta.DescriptionKey, spaceId);
-                existing.Remove(mediaId);
-            }
-
-            foreach (var dto in normalizedItems)
-            {
-                if (dto.LinkLocalizations == null || dto.LinkLocalizations.Count == 0)
-                {
-                    continue;
-                }
-
-                if (string.IsNullOrWhiteSpace(dto.Id))
-                {
-                    var createDto = new MediaCreateDto
-                    {
-                        MediaTypeId = dto.MediaTypeId,
-                        TextKey = dto.TextKey,
-                        DescriptionKey = dto.DescriptionKey,
-                        LinkLocalizations = dto.LinkLocalizations,
-                        TextLocalizations = null,
-                        DescriptionLocalizations = null
-                    };
-
-                    var mediaId = await InsertMediaAsync(conn, tx, spaceId, createDto);
-                    await InsertBoothMediaAsync(conn, tx, boothId, mediaId);
-                }
-                else
-                {
-                    var mediaId = dto.Id!;
-
-                    const string updateSql = @"
-                    UPDATE media
-                       SET media_type_id = @MediaTypeId,
-                           text_key = @TextKey,
-                           description_key = @DescKey
-                     WHERE id = @MediaId
-                       AND space_id = @SpaceId;";
-
-                    await using (var cmd = _db.CreateCommand(conn, updateSql))
-                    {
-                        cmd.Transaction = tx;
-                        cmd.Parameters.Add(_db.CreateParameter("@MediaTypeId", dto.MediaTypeId));
-                        cmd.Parameters.Add(_db.CreateParameter("@TextKey", (object?)dto.TextKey ?? DBNull.Value));
-                        cmd.Parameters.Add(_db.CreateParameter("@DescKey", (object?)dto.DescriptionKey ?? DBNull.Value));
-                        cmd.Parameters.Add(_db.CreateParameter("@MediaId", mediaId));
-                        cmd.Parameters.Add(_db.CreateParameter("@SpaceId", spaceId));
-                        await cmd.ExecuteNonQueryAsync();
-                    }
-
-                    await ReplaceMediaLocalizationsAsync(conn, tx, mediaId, dto.LinkLocalizations);
-
-                    if (!existing.ContainsKey(mediaId))
-                    {
-                        await InsertBoothMediaAsync(conn, tx, boothId, mediaId);
-                    }
-                }
-            }
-        }
 
         private async Task<string> InsertMediaAsync(
             DbConnection conn,
@@ -1110,9 +1013,9 @@ VALUES (@MediaId, @LocaleId, @MediaLink);";
             return result;
         }
 
-        private static List<MediaUpdateDto> NormalizeMediaUpdates(List<MediaUpdateDto>? mediaItems, HashSet<string> supportedLocales)
+        private static List<BoothMediaUpdateDto> NormalizeBoothMediaUpdates(List<BoothMediaUpdateDto>? mediaItems, HashSet<string> supportedLocales)
         {
-            var result = new List<MediaUpdateDto>();
+            var result = new List<BoothMediaUpdateDto>();
             if (mediaItems == null)
                 return result;
 
@@ -1125,9 +1028,8 @@ VALUES (@MediaId, @LocaleId, @MediaLink);";
                 if (links.Count == 0)
                     continue;
 
-                result.Add(new MediaUpdateDto
+                result.Add(new BoothMediaUpdateDto
                 {
-                    Id = item.Id,
                     MediaTypeId = item.MediaTypeId,
                     TextKey = item.TextKey,
                     DescriptionKey = item.DescriptionKey,
@@ -1343,6 +1245,32 @@ VALUES (@MediaId, @LocaleId, @MediaLink);";
 
             try
             {
+                // 0) Fetch immutable booth data (name_key) and ensure booth exists
+                const string fetchBoothKeySql = @"SELECT name_key FROM booth WHERE id = @BoothId AND space_id = @SpaceId;";
+                string? boothNameKey;
+
+                await using (var fetchCmd = _db.CreateCommand(conn, fetchBoothKeySql))
+                {
+                    fetchCmd.Transaction = tx;
+                    fetchCmd.Parameters.Add(_db.CreateParameter("@BoothId", boothId));
+                    fetchCmd.Parameters.Add(_db.CreateParameter("@SpaceId", spaceId));
+
+                    var result = await fetchCmd.ExecuteScalarAsync();
+                    if (result is null || result == DBNull.Value)
+                    {
+                        await tx.RollbackAsync();
+                        return null;
+                    }
+
+                    boothNameKey = Convert.ToString(result);
+                }
+
+                if (string.IsNullOrWhiteSpace(boothNameKey))
+                {
+                    await tx.RollbackAsync();
+                    return null;
+                }
+
                 // 1) Validate map_spot exists
                 const string validateSpotSql = @"SELECT COUNT(1) FROM map_spot WHERE id = @MapSpotId;";
                 await using (var cmd = _db.CreateCommand(conn, validateSpotSql))
@@ -1365,7 +1293,7 @@ VALUES (@MediaId, @LocaleId, @MediaLink);";
                 await using (var cmd = _db.CreateCommand(conn, updBooth))
                 {
                     cmd.Transaction = tx;
-                    cmd.Parameters.Add(_db.CreateParameter("@NameKey", dto.LocalizedPairs.Key));
+                    cmd.Parameters.Add(_db.CreateParameter("@NameKey", boothNameKey));
                     cmd.Parameters.Add(_db.CreateParameter("@BoothId", boothId));
                     cmd.Parameters.Add(_db.CreateParameter("@SpaceId", spaceId));
                     cmd.Parameters.Add(_db.CreateParameter("@MapSpotId", dto.MapSpotId));
@@ -1427,7 +1355,7 @@ VALUES (@MediaId, @LocaleId, @MediaLink);";
                         throw new InvalidOperationException($"Unsupported locales: {string.Join(", ", unsupported)}");
                 }
 
-                var normalizedMedia = NormalizeMediaUpdates(dto.MediaItems, supported);
+                var normalizedMedia = NormalizeBoothMediaUpdates(dto.MediaItems, supported);
 
                 // 4) Upsert i18n for booth name_key
                 const string updI18n = @"
@@ -1444,7 +1372,7 @@ VALUES (@MediaId, @LocaleId, @MediaLink);";
                     {
                         await using var cmdUp = _db.CreateCommand(conn, updI18n);
                         cmdUp.Transaction = tx;
-                        cmdUp.Parameters.Add(_db.CreateParameter("@NameKey", dto.LocalizedPairs.Key));
+                        cmdUp.Parameters.Add(_db.CreateParameter("@NameKey", boothNameKey));
                         cmdUp.Parameters.Add(_db.CreateParameter("@LocaleId", loc.LocaleId));
                         cmdUp.Parameters.Add(_db.CreateParameter("@Value", loc.Value ?? string.Empty));
                         cmdUp.Parameters.Add(_db.CreateParameter("@SpaceId", spaceId));
@@ -1453,7 +1381,7 @@ VALUES (@MediaId, @LocaleId, @MediaLink);";
                         {
                             await using var cmdIn = _db.CreateCommand(conn, insI18n);
                             cmdIn.Transaction = tx;
-                            cmdIn.Parameters.Add(_db.CreateParameter("@NameKey", dto.LocalizedPairs.Key));
+                            cmdIn.Parameters.Add(_db.CreateParameter("@NameKey", boothNameKey));
                             cmdIn.Parameters.Add(_db.CreateParameter("@LocaleId", loc.LocaleId));
                             cmdIn.Parameters.Add(_db.CreateParameter("@Value", loc.Value ?? string.Empty));
                             cmdIn.Parameters.Add(_db.CreateParameter("@SpaceId", spaceId));
@@ -1468,6 +1396,116 @@ VALUES (@MediaId, @LocaleId, @MediaLink);";
 
                 // 5) Reload and return the updated booth
                 return await LoadBoothByIdAsync(conn, spaceId, boothId);
+            }
+            catch
+            {
+                await tx.RollbackAsync();
+                throw;
+            }
+        }
+
+        public async Task<MediaData?> AddMediaToBoothAsync(int spaceId, int boothId, MediaCreateDto dto)
+        {
+            if (dto is null)
+                throw new ArgumentNullException(nameof(dto));
+
+            await using var conn = await _db.OpenConnectionAsync();
+            await using var tx = await conn.BeginTransactionAsync();
+
+            try
+            {
+                const string boothExistsSql = @"SELECT COUNT(1) FROM booth WHERE id = @BoothId AND space_id = @SpaceId;";
+
+                await using (var existsCmd = _db.CreateCommand(conn, boothExistsSql))
+                {
+                    existsCmd.Transaction = tx;
+                    existsCmd.Parameters.Add(_db.CreateParameter("@BoothId", boothId));
+                    existsCmd.Parameters.Add(_db.CreateParameter("@SpaceId", spaceId));
+
+                    var exists = Convert.ToInt32(await existsCmd.ExecuteScalarAsync()) > 0;
+                    if (!exists)
+                    {
+                        await tx.RollbackAsync();
+                        return null;
+                    }
+                }
+
+                var allLocales = new List<string>();
+
+                void AddLocales(IEnumerable<LocalizedValue>? values)
+                {
+                    if (values == null)
+                        return;
+
+                    foreach (var val in values.Where(v => !string.IsNullOrWhiteSpace(v?.LocaleId)))
+                        allLocales.Add(val!.LocaleId);
+                }
+
+                if (dto.LinkLocalizations != null)
+                {
+                    foreach (var loc in dto.LinkLocalizations.Where(l => !string.IsNullOrWhiteSpace(l?.LocaleId)))
+                        allLocales.Add(loc!.LocaleId);
+                }
+
+                AddLocales(dto.TextLocalizations);
+                AddLocales(dto.DescriptionLocalizations);
+
+                allLocales = allLocales
+                    .Where(s => !string.IsNullOrWhiteSpace(s))
+                    .Select(s => s!)
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToList();
+
+                var supported = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                if (allLocales.Count > 0)
+                {
+                    const string checkSupportedSqlBase = @"
+                    SELECT locale_id
+                      FROM supported_languages
+                     WHERE locale_id IN ({0})
+                       AND space_id = @SpaceId;";
+
+                    var paramNames = allLocales.Select((_, i) => $"@loc{i}").ToList();
+                    var query = string.Format(checkSupportedSqlBase, string.Join(", ", paramNames));
+
+                    await using (var checkCmd = _db.CreateCommand(conn, query))
+                    {
+                        checkCmd.Transaction = tx;
+                        for (int i = 0; i < allLocales.Count; i++)
+                            checkCmd.Parameters.Add(_db.CreateParameter(paramNames[i], allLocales[i]));
+                        checkCmd.Parameters.Add(_db.CreateParameter("@SpaceId", spaceId));
+
+                        await using var rdr = await checkCmd.ExecuteReaderAsync();
+                        while (await rdr.ReadAsync())
+                            supported.Add(rdr.IsDBNull(0) ? string.Empty : rdr.GetString(0));
+                    }
+                }
+
+                var normalizedList = NormalizeMediaCreates(new List<MediaCreateDto> { dto }, supported);
+                if (normalizedList.Count == 0)
+                    throw new InvalidOperationException("Media link localizations are required to add booth media.");
+
+                var normalized = normalizedList[0];
+
+                var mediaId = await InsertMediaAsync(conn, tx, spaceId, normalized);
+                await InsertBoothMediaAsync(conn, tx, boothId, mediaId);
+
+                await tx.CommitAsync();
+
+                return new MediaData
+                {
+                    Id = mediaId,
+                    MediaTypeId = normalized.MediaTypeId,
+                    TextKey = normalized.TextKey,
+                    DescriptionKey = normalized.DescriptionKey,
+                    LinkLocalizations = normalized.LinkLocalizations?
+                        .Select(l => new MediaLocalization
+                        {
+                            LocaleId = l.LocaleId,
+                            MediaLink = l.MediaLink
+                        })
+                        .ToList() ?? new List<MediaLocalization>()
+                };
             }
             catch
             {

--- a/Repositories/Interfaces/IBoothRepository.cs
+++ b/Repositories/Interfaces/IBoothRepository.cs
@@ -11,8 +11,9 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
     public interface IBoothRepository
     {
         Task<List<BoothModel>> GetAllBoothsBySpaceAsync(int spaceId);
-        Task<BoothModel> UpdateBoothAsync(int spaceId, int boothId, BoothUpdateDto dto);
+        Task<BoothModel?> UpdateBoothAsync(int spaceId, int boothId, BoothUpdateDto dto);
         Task<BoothModel> CreateBoothAsync(int spaceId, BoothCreateDto boothDto);
+        Task<MediaData?> AddMediaToBoothAsync(int spaceId, int boothId, MediaCreateDto dto);
         Task<bool> DeleteBoothCascadeAsync(int spaceId, int boothId);
     }
 }

--- a/TifoXRCoreWebAPI.Tests/Controllers/BoothControllerTests.cs
+++ b/TifoXRCoreWebAPI.Tests/Controllers/BoothControllerTests.cs
@@ -236,6 +236,72 @@ namespace GMS.TifoXRCoreWebAPI.Tests.Controllers
             wrapper.booth.Should().BeEquivalentTo(created);
         }
 
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-1)]
+        public async Task AddMediaToBooth_ThrowsArgEx_OnInvalidSpaceId(int spaceId)
+        {
+            var mediaDto = new MediaCreateDto { MediaTypeId = 1 };
+
+            await Assert.ThrowsAsync<ArgumentException>(() => sut.AddMediaToBooth(spaceId, 10, mediaDto));
+
+            repo.Verify(r => r.AddMediaToBoothAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<MediaCreateDto>()), Times.Never);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-5)]
+        public async Task AddMediaToBooth_ThrowsArgEx_OnInvalidBoothId(int boothId)
+        {
+            var mediaDto = new MediaCreateDto { MediaTypeId = 1 };
+
+            await Assert.ThrowsAsync<ArgumentException>(() => sut.AddMediaToBooth(3, boothId, mediaDto));
+
+            repo.Verify(r => r.AddMediaToBoothAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<MediaCreateDto>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task AddMediaToBooth_ThrowsArgNullEx_OnNullDto()
+        {
+            await Assert.ThrowsAsync<ArgumentNullException>(() => sut.AddMediaToBooth(3, 4, null!));
+
+            repo.Verify(r => r.AddMediaToBoothAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<MediaCreateDto>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task AddMediaToBooth_ThrowsNotFound_WhenRepoReturnsNull()
+        {
+            repo.Setup(r => r.AddMediaToBoothAsync(3, 4, It.IsAny<MediaCreateDto>()))
+                .ReturnsAsync((MediaData?)null);
+
+            var dto = new MediaCreateDto { MediaTypeId = 2 };
+
+            await Assert.ThrowsAsync<ResourceNotFoundException>(() => sut.AddMediaToBooth(3, 4, dto));
+        }
+
+        [Fact]
+        public async Task AddMediaToBooth_ReturnsCreated_OnSuccess()
+        {
+            var dto = new MediaCreateDto { MediaTypeId = 2 };
+            var created = new MediaData
+            {
+                Id = "media-guid",
+                MediaTypeId = 2,
+                LinkLocalizations = new List<MediaLocalization>
+                {
+                    new() { LocaleId = "en_us", MediaLink = "https://cdn/en" }
+                }
+            };
+
+            repo.Setup(r => r.AddMediaToBoothAsync(5, 9, dto)).ReturnsAsync(created);
+
+            var result = await sut.AddMediaToBooth(5, 9, dto);
+
+            var createdResult = result.Result.Should().BeOfType<CreatedAtActionResult>().Subject;
+            createdResult.Value.Should().Be(created);
+            repo.Verify(r => r.AddMediaToBoothAsync(5, 9, dto), Times.Once);
+        }
+
         #endregion
 
         #region PUT
@@ -356,15 +422,15 @@ namespace GMS.TifoXRCoreWebAPI.Tests.Controllers
         /// The repository throws an ArgumentException and the controller propagates it.
         /// </summary>
         [Fact]
-        public async Task UpdateBooth_ThrowsArgEx_WhenMapSpotIsNull()
+        public async Task UpdateBooth_ThrowsArgEx_WhenMapSpotIdInvalid()
         {
             // ARRANGE
             var dto = new BoothUpdateDtoBuilder()
-                        .WithNullMapSpot()
+                        .WithMapSpotId(0)
                         .Build();
 
             repo.Setup(r => r.UpdateBoothAsync(1, 1, dto))
-                .ThrowsAsync(new ArgumentException("MapSpot cannot be null."));
+                .ThrowsAsync(new ArgumentException("MapSpotId must be positive."));
 
             // ACT & ASSERT
             await Assert.ThrowsAsync<ArgumentException>(() => sut.UpdateBooth(1, 1, dto));

--- a/TifoXRCoreWebAPI.Tests/Helpers/BoothUpdateDtoBuilder.cs
+++ b/TifoXRCoreWebAPI.Tests/Helpers/BoothUpdateDtoBuilder.cs
@@ -15,15 +15,12 @@ namespace GMS.TifoXRCoreWebAPI.Tests.Helpers
     /// </summary>
     public class BoothUpdateDtoBuilder
     {
-        private string _key = "booth_key";
         private List<LocalizedValue>? _values = new()
         {
             new LocalizedValue { LocaleId = "en_us", Value = "Booth Name" }
         };
-        private MapSpotModel? _mapSpot = new() { X = 1.0m, Y = 2.0m, Z = 3.0m };
-
+        private int _mapSpotId = 1;
         private bool _nullLocalizedPairs = false;
-        private bool _nullMapSpot = false;
 
         /// <summary>
         /// Explicitly nulls the LocalizedPairs object to model invalid input scenarios.
@@ -34,12 +31,9 @@ namespace GMS.TifoXRCoreWebAPI.Tests.Helpers
             return this;
         }
 
-        /// <summary>
-        /// Explicitly nulls the MapSpot object to model invalid input scenarios.
-        /// </summary>
-        public BoothUpdateDtoBuilder WithNullMapSpot()
+        public BoothUpdateDtoBuilder WithMapSpotId(int mapSpotId)
         {
-            _nullMapSpot = true;
+            _mapSpotId = mapSpotId;
             return this;
         }
 
@@ -52,12 +46,11 @@ namespace GMS.TifoXRCoreWebAPI.Tests.Helpers
             {
                 LocalizedPairs = _nullLocalizedPairs
                     ? null!
-                    : new LocalizedPairs
+                    : new BoothLocalizedPairsUpdateDto
                     {
-                        Key = _key,
                         Values = _values ?? new List<LocalizedValue>()
                     },
-                MapSpot = _nullMapSpot ? null! : _mapSpot!
+                MapSpotId = _mapSpotId
             };
         }
     }

--- a/TifoXRCoreWebAPI.Tests/Repositories/BoothRepositoryTests.cs
+++ b/TifoXRCoreWebAPI.Tests/Repositories/BoothRepositoryTests.cs
@@ -22,13 +22,12 @@ namespace GMS.TifoXRCoreWebAPI.Tests.Repositories
     public class BoothRepositoryTests
     {
 
-        private static BoothUpdateDto Dto(int spotId, string key, params (string loc, string val)[] pairs)
+        private static BoothUpdateDto Dto(int spotId, params (string loc, string val)[] pairs)
             => new BoothUpdateDto
             {
                 MapSpotId = spotId,
-                LocalizedPairs = new LocalizedPairs
+                LocalizedPairs = new BoothLocalizedPairsUpdateDto
                 {
-                    Key = key,
                     Values = pairs.Select(p => new LocalizedValue { LocaleId = p.loc, Value = p.val }).ToList()
                 }
             };
@@ -376,10 +375,11 @@ namespace GMS.TifoXRCoreWebAPI.Tests.Repositories
         public async Task MapSpotMissingThrows()
         {
             var fake = new FakeDbProvider(() => throw new InvalidOperationException("no reader expected"));
+            fake.EnqueueScalar("bth_key"); // existing booth name key
             fake.EnqueueScalar(0); // validate spot
 
             var sut = new BoothRepository(MakeConfig(), fake);
-            var act = () => sut.UpdateBoothAsync(1, 99, Dto(999, "bth_key", ("en_us", "X")));
+            var act = () => sut.UpdateBoothAsync(1, 99, Dto(999, ("en_us", "X")));
 
             await act.Should().ThrowAsync<InvalidOperationException>()
                      .WithMessage("MapSpot*does not exist*");
@@ -390,11 +390,12 @@ namespace GMS.TifoXRCoreWebAPI.Tests.Repositories
         public async Task UpdateNoRowsNull()
         {
             var fake = new FakeDbProvider(() => throw new InvalidOperationException("no reader expected"));
+            fake.EnqueueScalar("bth_key"); // existing booth name key
             fake.EnqueueScalar(1); // spot ok
             fake.EnqueueNonQuery(0); // update 0 rows
 
             var sut = new BoothRepository(MakeConfig(), fake);
-            var res = await sut.UpdateBoothAsync(1, 10, Dto(5, "bth_key", ("en_us", "Booth")));
+            var res = await sut.UpdateBoothAsync(1, 10, Dto(5, ("en_us", "Booth")));
 
             res.Should().BeNull();
         }
@@ -404,12 +405,13 @@ namespace GMS.TifoXRCoreWebAPI.Tests.Repositories
         public async Task UnsupportedLocalesThrows()
         {
             var fake = new FakeDbProvider(() => throw new InvalidOperationException("unexpected fallback"));
+            fake.EnqueueScalar("bth_key");          // existing booth name key
             fake.EnqueueScalar(1);          // spot ok
             fake.EnqueueNonQuery(1);        // update ok
             fake.EnqueueReader(() => Langs("en_us")); // supported langs
 
             var sut = new BoothRepository(MakeConfig(), fake);
-            var act = () => sut.UpdateBoothAsync(1, 10, Dto(5, "bth_key", ("en_us", "Hello"), ("fr_fr", "Bonjour")));
+            var act = () => sut.UpdateBoothAsync(1, 10, Dto(5, ("en_us", "Hello"), ("fr_fr", "Bonjour")));
 
             await act.Should().ThrowAsync<InvalidOperationException>()
                      .WithMessage("*Unsupported locales:*fr_fr*");
@@ -420,6 +422,7 @@ namespace GMS.TifoXRCoreWebAPI.Tests.Repositories
         public async Task UpdateOkUpsertAndReload()
         {
             var fake = new FakeDbProvider(() => throw new InvalidOperationException("unexpected fallback"));
+            fake.EnqueueScalar("bth_key");          // existing booth name key
             fake.EnqueueScalar(1);                 // spot ok
             fake.EnqueueNonQuery(1);               // update booth -> 1
             fake.EnqueueReader(() => Langs("en_us", "es_es")); // both supported
@@ -435,7 +438,7 @@ namespace GMS.TifoXRCoreWebAPI.Tests.Repositories
             fake.EnqueueReader(BoothMediaEmpty);   // reload media
 
             var sut = new BoothRepository(MakeConfig(), fake);
-            var dto = Dto(5, "bth_key", ("en_us", "Hello"), ("es_es", "Hola"));
+            var dto = Dto(5, ("en_us", "Hello"), ("es_es", "Hola"));
 
             var res = await sut.UpdateBoothAsync(1, 10, dto);
 
@@ -456,8 +459,9 @@ namespace GMS.TifoXRCoreWebAPI.Tests.Repositories
         public async Task UpdateOkNoLocalesReloadOnly()
         {
             var fake = new FakeDbProvider(() => throw new InvalidOperationException("unexpected fallback"));
-            var dto = new BoothUpdateDto { MapSpotId = 7, LocalizedPairs = new LocalizedPairs { Key = "bth_key", Values = null } };
+            var dto = new BoothUpdateDto { MapSpotId = 7, LocalizedPairs = new BoothLocalizedPairsUpdateDto { Values = null } };
 
+            fake.EnqueueScalar("bth_key"); // existing booth name key
             fake.EnqueueScalar(1); // spot ok
             fake.EnqueueNonQuery(1); // update booth
             fake.EnqueueReader(BoothMediaEmpty); // existing booth_media
@@ -480,21 +484,20 @@ namespace GMS.TifoXRCoreWebAPI.Tests.Repositories
         }
 
         [Fact]
-        public async Task UpdateAddsNewMedia()
+        public async Task UpdateRejectsAddingNewMedia()
         {
             var fake = new FakeDbProvider(() => throw new InvalidOperationException("unexpected fallback"));
             var dto = new BoothUpdateDto
             {
                 MapSpotId = 9,
-                LocalizedPairs = new LocalizedPairs
+                LocalizedPairs = new BoothLocalizedPairsUpdateDto
                 {
-                    Key = "bth_key",
                     Values = new List<LocalizedValue>
                     {
                         new() { LocaleId = "en_us", Value = "Name" }
                     }
                 },
-                MediaItems = new List<MediaUpdateDto>
+                MediaItems = new List<BoothMediaUpdateDto>
                 {
                     new()
                     {
@@ -507,33 +510,69 @@ namespace GMS.TifoXRCoreWebAPI.Tests.Repositories
                 }
             };
 
+            fake.EnqueueScalar("bth_key"); // existing booth name key
             fake.EnqueueScalar(1); // map spot ok
             fake.EnqueueNonQuery(1); // update booth
             fake.EnqueueReader(() => Langs("en_us")); // supported locales
-            fake.EnqueueNonQuery(0); // update i18n -> 0 rows
-            fake.EnqueueNonQuery(1); // insert i18n
-            fake.EnqueueReader(BoothMediaEmpty); // fetch existing booth media
-            fake.EnqueueScalar("media-new"); // SELECT UUID()
-            fake.EnqueueNonQuery(1); // insert media row
-            fake.EnqueueNonQuery(1); // insert media localization
-            fake.EnqueueNonQuery(1); // delete existing booth_media mapping (none)
-            fake.EnqueueNonQuery(1); // insert booth_media mapping
-            fake.EnqueueReader(() => ReloadRows(
-                id: 33, spaceId: 2, key: "bth_key", mapSpotId: 9,
-                x: 0m, y: 0m, z: 0m,
-                ("en_us", "Name")
-            ));
-            fake.EnqueueReader(() => BoothMediaRows(
-                (33, "media-new", 4, null, null, "en_us", "https://cdn/en")
-            ));
+            fake.EnqueueReader(BoothMediaEmpty); // fetch existing booth media (none)
 
             var sut = new BoothRepository(MakeConfig(), fake);
-            var result = await sut.UpdateBoothAsync(2, 33, dto);
+            var act = () => sut.UpdateBoothAsync(2, 33, dto);
+
+            await act.Should().ThrowAsync<InvalidOperationException>()
+                .WithMessage("No media exists for this booth to update.");
+        }
+
+        [Fact]
+        public async Task AddMediaToBoothReturnsNullWhenBoothMissing()
+        {
+            var fake = new FakeDbProvider(() => throw new InvalidOperationException("unexpected fallback"));
+            fake.EnqueueScalar(0); // booth count
+
+            var sut = new BoothRepository(MakeConfig(), fake);
+            var dto = new MediaCreateDto
+            {
+                MediaTypeId = 4,
+                LinkLocalizations = new List<MediaLocalization>
+                {
+                    new() { LocaleId = "en_us", MediaLink = "https://cdn/en" }
+                }
+            };
+
+            var result = await sut.AddMediaToBoothAsync(1, 99, dto);
+
+            result.Should().BeNull();
+        }
+
+        [Fact]
+        public async Task AddMediaToBoothCreatesMediaAndMapping()
+        {
+            var fake = new FakeDbProvider(() => throw new InvalidOperationException("unexpected fallback"));
+            var dto = new MediaCreateDto
+            {
+                MediaTypeId = 4,
+                LinkLocalizations = new List<MediaLocalization>
+                {
+                    new() { LocaleId = "en_us", MediaLink = "https://cdn/en" },
+                    new() { LocaleId = "jp_jp", MediaLink = "https://cdn/jp" }
+                }
+            };
+
+            fake.EnqueueScalar(1); // booth exists
+            fake.EnqueueReader(() => Langs("en_us")); // supported locales (jp_jp filtered)
+            fake.EnqueueScalar("media-guid"); // SELECT UUID()
+            fake.EnqueueNonQuery(1); // insert media row
+            fake.EnqueueNonQuery(1); // insert media_localization en_us
+            fake.EnqueueNonQuery(0); // delete existing booth_media mapping
+            fake.EnqueueNonQuery(1); // insert booth_media mapping
+
+            var sut = new BoothRepository(MakeConfig(), fake);
+            var result = await sut.AddMediaToBoothAsync(1, 33, dto);
 
             result.Should().NotBeNull();
-            result!.MediaItems.Should().ContainSingle(m => m.Id == "media-new");
-            result.MediaItems[0].LinkLocalizations.Should()
-                .ContainSingle(l => l.LocaleId == "en_us" && l.MediaLink == "https://cdn/en");
+            result!.Id.Should().Be("media-guid");
+            result.LinkLocalizations.Should().ContainSingle(l => l.LocaleId == "en_us" && l.MediaLink == "https://cdn/en");
+            result.LinkLocalizations.Should().NotContain(l => l.LocaleId == "jp_jp");
         }
 
 


### PR DESCRIPTION
## Summary
- remove mutable fields from the booth update DTO and adjust repository logic to reload the existing name key and map booth media updates without client-provided IDs
- add a booth media creation endpoint and repository helper that validates locales and generates media identifiers
- refresh unit tests and builders to reflect the new contract and cover the media creation workflow

## Testing
- dotnet test *(fails: `dotnet`: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e7c9abb09c8329867297ce167019bc