### PR TITLE
Add booth media deletion endpoint

### DIFF
--- a/Controllers/BoothController.cs
+++ b/Controllers/BoothController.cs
@@ -284,6 +284,56 @@ namespace GMS.TifoXRCoreWebAPI.Controllers
             return NoContent();
         }
 
+        /// <summary>
+        /// DELETE /api/space/{spaceId}/booth/{boothId}/media/{mediaId}
+        /// Removes a media record from the booth along with its localized values.
+        /// </summary>
+        [HttpDelete("{spaceId}/booth/{boothId}/media/{mediaId}")]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+        public async Task<IActionResult> DeleteBoothMedia(
+            [FromRoute] int spaceId,
+            [FromRoute] int boothId,
+            [FromRoute] string mediaId)
+        {
+            if (spaceId <= 0)
+                throw ErrorService.Exception(
+                    ErrorType.Argument,
+                    nameof(DeleteBoothMedia),
+                    ErrorMessages.Validation.PositiveIntRequired,
+                    paramName: nameof(spaceId),
+                    parameters: new { spaceId, boothId, mediaId });
+
+            if (boothId <= 0)
+                throw ErrorService.Exception(
+                    ErrorType.Argument,
+                    nameof(DeleteBoothMedia),
+                    ErrorMessages.Validation.PositiveIntRequired,
+                    paramName: nameof(boothId),
+                    parameters: new { spaceId, boothId, mediaId });
+
+            if (string.IsNullOrWhiteSpace(mediaId))
+                throw ErrorService.Exception(
+                    ErrorType.Argument,
+                    nameof(DeleteBoothMedia),
+                    ErrorMessages.Validation.MissingParameter,
+                    paramName: nameof(mediaId),
+                    parameters: new { spaceId, boothId, mediaId });
+
+            var deleted = await _boothRepository.DeleteBoothMediaAsync(spaceId, boothId, mediaId);
+
+            if (!deleted)
+                throw ErrorService.Exception(
+                    ErrorType.NotFound,
+                    nameof(DeleteBoothMedia),
+                    ErrorMessages.Http.NotFound,
+                    parameters: new { spaceId, boothId, mediaId });
+
+            return NoContent();
+        }
+
         #endregion
     }
 }

--- a/Repositories/BoothRepository.cs
+++ b/Repositories/BoothRepository.cs
@@ -963,6 +963,60 @@ VALUES (@MediaId, @LocaleId, @MediaLink);";
             }
         }
 
+        public async Task<bool> DeleteBoothMediaAsync(int spaceId, int boothId, string mediaId)
+        {
+            if (string.IsNullOrWhiteSpace(mediaId))
+                throw new ArgumentException("Media ID is required.", nameof(mediaId));
+
+            await using var conn = await _db.OpenConnectionAsync();
+            await using var tx = await conn.BeginTransactionAsync();
+
+            try
+            {
+                const string lookupSql = @"
+                SELECT m.text_key, m.description_key
+                  FROM booth_media bm
+                  INNER JOIN booth b ON bm.booth_id = b.id
+                  LEFT JOIN media m ON m.id = bm.media_id
+                 WHERE b.space_id = @SpaceId
+                   AND b.id = @BoothId
+                   AND bm.media_id = @MediaId;";
+
+                string? textKey = null;
+                string? descriptionKey = null;
+
+                await using (var lookupCmd = _db.CreateCommand(conn, lookupSql))
+                {
+                    lookupCmd.Transaction = tx;
+                    lookupCmd.Parameters.Add(_db.CreateParameter("@SpaceId", spaceId));
+                    lookupCmd.Parameters.Add(_db.CreateParameter("@BoothId", boothId));
+                    lookupCmd.Parameters.Add(_db.CreateParameter("@MediaId", mediaId));
+
+                    await using var reader = await lookupCmd.ExecuteReaderAsync();
+                    if (!await reader.ReadAsync())
+                    {
+                        await tx.RollbackAsync();
+                        return false;
+                    }
+
+                    if (!reader.IsDBNull(0))
+                        textKey = reader.GetString(0);
+                    if (!reader.IsDBNull(1))
+                        descriptionKey = reader.GetString(1);
+                }
+
+                await DeleteMediaCascadeAsync(conn, tx, boothId, mediaId, textKey, descriptionKey, spaceId);
+
+                await tx.CommitAsync();
+                return true;
+            }
+            catch
+            {
+                await tx.RollbackAsync();
+                throw;
+            }
+        }
+
         private async Task<BoothModel?> LoadBoothByIdAsync(DbConnection conn, int spaceId, int boothId)
         {
             const string sql = @"

--- a/Repositories/Interfaces/IBoothRepository.cs
+++ b/Repositories/Interfaces/IBoothRepository.cs
@@ -15,6 +15,7 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
         Task<BoothModel?> UpdateBoothAsync(int spaceId, int boothId, BoothUpdateDto dto);
         Task<BoothModel> CreateBoothAsync(int spaceId, BoothCreateDto boothDto);
         Task<MediaData?> AddMediaToBoothAsync(int spaceId, int boothId, MediaCreateDto dto);
+        Task<bool> DeleteBoothMediaAsync(int spaceId, int boothId, string mediaId);
         Task<bool> DeleteBoothCascadeAsync(int spaceId, int boothId);
     }
 }


### PR DESCRIPTION
## Summary
- add a booth controller endpoint to delete a media item with validation and consistent errors
- implement repository support to cascade delete booth media, media rows, and localized values
- expose the new delete method on the booth repository interface

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e8403d90b88329a826ff312cf8a9ab