### PR TITLE
Filter pending intents by gateway

### DIFF
--- a/Controllers/OrderController.cs
+++ b/Controllers/OrderController.cs
@@ -59,13 +59,20 @@ namespace GMS.TifoXRCoreWebAPI.Controllers
         // ------------- Payment Intents (queries) -------------
 
         [HttpGet("{orderId}/checkout/pending")]
-        public Task<ActionResult<PendingIntentResponse>> GetCheckoutForOrder(int spaceId, string orderId)
-            => Handle(() => _paymentQueries.GetPendingForOrderAsync(spaceId, orderId));
+        public Task<ActionResult<PendingIntentResponse>> GetCheckoutForOrder(
+            int spaceId,
+            string orderId,
+            [FromQuery] int? gatewayId)
+            => Handle(() => _paymentQueries.GetPendingForOrderAsync(spaceId, orderId, gatewayId));
 
         [HttpGet("checkout/by-item")]
         public Task<ActionResult<PendingIntentResponse>> FindPendingIntentByItem(
-            int spaceId, [FromQuery] string userId, [FromQuery] int itemTypeId, [FromQuery] int itemRefId)
-            => Handle(() => _paymentQueries.FindPendingByItemAsync(spaceId, userId, itemTypeId, itemRefId));
+            int spaceId,
+            [FromQuery] string userId,
+            [FromQuery] int itemTypeId,
+            [FromQuery] int itemRefId,
+            [FromQuery] int? gatewayId)
+            => Handle(() => _paymentQueries.FindPendingByItemAsync(spaceId, userId, itemTypeId, itemRefId, gatewayId));
 
         // ------------- Payments -------------
 

--- a/Repositories/Interfaces/IOrderRepository.Payments.cs
+++ b/Repositories/Interfaces/IOrderRepository.Payments.cs
@@ -14,10 +14,10 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
 
         Task<(string IntentId, int StatusId, string IdempotencyKey, string? ProviderIntentId,
               int PaymentGatewayId, long AmountMinor, int CurrencyId)?>
-            GetPendingIntentForOrderAsync(string orderId);
+            GetPendingIntentForOrderAsync(string orderId, int? gatewayId);
 
         Task<string?> FindLatestOrderIdWithPendingIntentAsync(int spaceId, string userId,
-            int itemTypeId, int itemRefId);
+            int itemTypeId, int itemRefId, int? gatewayId);
 
         Task<string> ResolveCurrencyIsoAsync(int currencyId);
 

--- a/Repositories/OrderRepository.Payments.cs
+++ b/Repositories/OrderRepository.Payments.cs
@@ -213,12 +213,13 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
 
         public async Task<(string IntentId, int StatusId, string IdempotencyKey, string? ProviderIntentId,
                           int PaymentGatewayId, long AmountMinor, int CurrencyId)?>
-            GetPendingIntentForOrderAsync(string orderId)
+            GetPendingIntentForOrderAsync(string orderId, int? gatewayId)
         {
             await using var conn = await _db.OpenConnectionAsync();
             await using var cmd = _db.CreateCommand(conn, Intent_FindPendingForOrder);
 
             cmd.Parameters.Add(_db.CreateParameter("@OrderId", orderId));
+            cmd.Parameters.Add(_db.CreateParameter("@GatewayId", gatewayId));
 
             await using var r = await cmd.ExecuteReaderAsync();
 
@@ -235,9 +236,9 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
             );
         }
 
-        // Matches: FindLatestOrderIdWithPendingIntentAsync(int, string, int, int)
+        // Matches: FindLatestOrderIdWithPendingIntentAsync(int, string, int, int, int?)
         public async Task<string?> FindLatestOrderIdWithPendingIntentAsync(
-            int spaceId, string userId, int itemTypeId, int itemRefId)
+            int spaceId, string userId, int itemTypeId, int itemRefId, int? gatewayId)
         {
             await using var conn = await _db.OpenConnectionAsync();
             await using var cmd = _db.CreateCommand(conn, Intent_FindLatestOrderWithPending);
@@ -246,6 +247,7 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
             cmd.Parameters.Add(_db.CreateParameter("@UserId", userId));
             cmd.Parameters.Add(_db.CreateParameter("@ItemTypeId", itemTypeId));
             cmd.Parameters.Add(_db.CreateParameter("@ItemRefId", itemRefId));
+            cmd.Parameters.Add(_db.CreateParameter("@GatewayId", gatewayId));
 
             var o = await cmd.ExecuteScalarAsync();
 

--- a/Repositories/Sql/OrderSql.cs
+++ b/Repositories/Sql/OrderSql.cs
@@ -99,7 +99,9 @@ namespace GMS.TifoXRCoreWebAPI.Repositories.SQL
             SELECT pi.id, pi.status_id, pi.idempotency_key, pi.provider_intent_id,
                    pi.payment_gateway_id, pi.amount, pi.currency_id
             FROM payment_intent pi
-            WHERE pi.order_id=@OrderId AND pi.status_id IN (1,2)
+            WHERE pi.order_id=@OrderId
+              AND pi.status_id IN (1,2)
+              AND (@GatewayId IS NULL OR pi.payment_gateway_id=@GatewayId)
             ORDER BY pi.creation_time DESC LIMIT 1;";
 
         internal const string Intent_FindByIdem = @"

--- a/Repositories/Sql/PaymentIntentSql.cs
+++ b/Repositories/Sql/PaymentIntentSql.cs
@@ -93,6 +93,7 @@ namespace GMS.TifoXRCoreWebAPI.Repositories.SQL
             JOIN payment_intent pi ON pi.order_id = o.id AND pi.status_id IN (1,2) -- requires_action / processing
             WHERE o.space_id=@SpaceId AND o.user_id=@UserId
               AND ol.item_type_id=@ItemTypeId AND ol.item_ref_id=@ItemRefId
+              AND (@GatewayId IS NULL OR pi.payment_gateway_id=@GatewayId)
             ORDER BY pi.creation_time DESC
             LIMIT 1;";
 

--- a/Services/Interfaces/IPaymentQueryService.cs
+++ b/Services/Interfaces/IPaymentQueryService.cs
@@ -11,7 +11,12 @@ namespace GMS.TifoXRCoreWebAPI.Services
 {
     public interface IPaymentQueryService
     {
-        Task<PendingIntentResponse> GetPendingForOrderAsync(int spaceId, string orderId);
-        Task<PendingIntentResponse> FindPendingByItemAsync(int spaceId, string userId, int itemTypeId, int itemRefId);
+        Task<PendingIntentResponse> GetPendingForOrderAsync(int spaceId, string orderId, int? gatewayId);
+        Task<PendingIntentResponse> FindPendingByItemAsync(
+            int spaceId,
+            string userId,
+            int itemTypeId,
+            int itemRefId,
+            int? gatewayId);
     }
 }

--- a/Services/PaymentQueryService.cs
+++ b/Services/PaymentQueryService.cs
@@ -20,7 +20,7 @@ namespace GMS.TifoXRCoreWebAPI.Services
         private readonly IOrderRepository _repo = repo;
         private readonly IPaymentGatewayResolver _resolver = resolver;
 
-        public async Task<PendingIntentResponse> GetPendingForOrderAsync(int spaceId, string orderId)
+        public async Task<PendingIntentResponse> GetPendingForOrderAsync(int spaceId, string orderId, int? gatewayId)
         {
             if (string.IsNullOrWhiteSpace(orderId))
                 throw new ArgumentException("orderId is required.", nameof(orderId));
@@ -28,13 +28,13 @@ namespace GMS.TifoXRCoreWebAPI.Services
             var order = await _repo.GetOrderAsync(spaceId, orderId);
             if (order is null) return new PendingIntentResponse { Found = false };
 
-            var pi = await _repo.GetPendingIntentForOrderAsync(orderId);
+            var pi = await _repo.GetPendingIntentForOrderAsync(orderId, gatewayId);
             if (pi is null) return new PendingIntentResponse { Found = false };
 
             // Unpack
             var intentId = pi.Value.IntentId;
             var providerIntentId = pi.Value.ProviderIntentId;
-            var gatewayId = pi.Value.PaymentGatewayId;
+            var gatewayIdFromDb = pi.Value.PaymentGatewayId;
             var statusId = pi.Value.StatusId;
             var idemKey = pi.Value.IdempotencyKey;
             var amtMinor = pi.Value.AmountMinor;
@@ -46,7 +46,7 @@ namespace GMS.TifoXRCoreWebAPI.Services
 
             if (statusId == (int)PaymentIntentStatus.RequiresAction || statusId == 1)
             {
-                var gateway = _resolver.GetById(gatewayId);
+                var gateway = _resolver.GetById(gatewayIdFromDb);
                 string? providerApprove = null;
 
                 if (!string.IsNullOrWhiteSpace(providerPidToUse))
@@ -58,7 +58,7 @@ namespace GMS.TifoXRCoreWebAPI.Services
                         // auto-refresh in place
                         var amountMajor = MoneyConverter.ToMajor(amtMinor);
                         var (newPid, newApproveLink) = await RefreshCryptoProviderIntentAsync(
-                            spaceId, orderId, intentId, gatewayId, amountMajor, currencyId);
+                            spaceId, orderId, intentId, gatewayIdFromDb, amountMajor, currencyId);
 
                         providerPidToUse = newPid;
                         providerApprove = newApproveLink;
@@ -81,7 +81,7 @@ namespace GMS.TifoXRCoreWebAPI.Services
                     StatusId = statusId,
                     IdempotencyKey = idemKey,
                     ProviderIntentId = providerPidToUse,       // may be refreshed
-                    PaymentGatewayId = gatewayId,
+                    PaymentGatewayId = gatewayIdFromDb,
                     AmountMinor = amtMinor,
                     CurrencyId = currencyId,
                     ApproveLink = approveLink
@@ -97,7 +97,7 @@ namespace GMS.TifoXRCoreWebAPI.Services
                 StatusId = statusId,
                 IdempotencyKey = idemKey,
                 ProviderIntentId = providerIntentId,
-                PaymentGatewayId = gatewayId,
+                PaymentGatewayId = gatewayIdFromDb,
                 AmountMinor = amtMinor,
                 CurrencyId = currencyId,
                 ApproveLink = null
@@ -105,18 +105,19 @@ namespace GMS.TifoXRCoreWebAPI.Services
         }
 
         public async Task<PendingIntentResponse> FindPendingByItemAsync(
-    int spaceId, string userId, int itemTypeId, int itemRefId)
+            int spaceId, string userId, int itemTypeId, int itemRefId, int? gatewayId)
         {
             if (string.IsNullOrWhiteSpace(userId))
                 throw new ArgumentException("userId is required.", nameof(userId));
 
-            var orderId = await _repo.FindLatestOrderIdWithPendingIntentAsync(spaceId, userId, itemTypeId, itemRefId);
+            var orderId = await _repo.FindLatestOrderIdWithPendingIntentAsync(
+                spaceId, userId, itemTypeId, itemRefId, gatewayId);
             if (string.IsNullOrWhiteSpace(orderId)) return new PendingIntentResponse { Found = false };
 
-            var pi = await _repo.GetPendingIntentForOrderAsync(orderId);
+            var pi = await _repo.GetPendingIntentForOrderAsync(orderId, gatewayId);
             if (pi is null) return new PendingIntentResponse { Found = false };
 
-            var (intentId, providerIntentId, gatewayId, statusId, idemKey, amtMinor, currencyId) =
+            var (intentId, providerIntentId, gatewayIdFromDb, statusId, idemKey, amtMinor, currencyId) =
                 (pi.Value.IntentId, pi.Value.ProviderIntentId, pi.Value.PaymentGatewayId,
                  pi.Value.StatusId, pi.Value.IdempotencyKey, pi.Value.AmountMinor, pi.Value.CurrencyId);
 
@@ -126,7 +127,7 @@ namespace GMS.TifoXRCoreWebAPI.Services
             // only try to build an approve link if we're pending
             if (statusId == 1 /* RequiresAction */ || statusId == 2 /* Processing */)
             {
-                var gateway = _resolver.GetById(gatewayId);
+                var gateway = _resolver.GetById(gatewayIdFromDb);
                 try
                 {
                     string? providerApprove = null;
@@ -141,7 +142,7 @@ namespace GMS.TifoXRCoreWebAPI.Services
                         {
                             var amountMajor = MoneyConverter.ToMajor(amtMinor);
                             var (newPid, newApproveLink) = await RefreshCryptoProviderIntentAsync(
-                                spaceId, orderId, intentId, gatewayId, amountMajor, currencyId);
+                                spaceId, orderId, intentId, gatewayIdFromDb, amountMajor, currencyId);
                             pidToUse = newPid;
                             providerApprove = newApproveLink;
                         }
@@ -171,7 +172,7 @@ namespace GMS.TifoXRCoreWebAPI.Services
                 StatusId = statusId,
                 IdempotencyKey = idemKey,
                 ProviderIntentId = pidToUse,
-                PaymentGatewayId = gatewayId,
+                PaymentGatewayId = gatewayIdFromDb,
                 AmountMinor = amtMinor,
                 CurrencyId = currencyId,
                 ApproveLink = approveLink


### PR DESCRIPTION
## Summary
- add an optional gatewayId query parameter to the pending checkout discovery endpoints
- plumb the gateway filter through payment query services and repository lookups to return gateway-specific pending intents

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68efbeb993e08329abdea7770d810121