### PR TITLE
Add API for teleport table button creation

### DIFF
--- a/Controllers/TeleportTableController.cs
+++ b/Controllers/TeleportTableController.cs
@@ -101,6 +101,67 @@ namespace GMS.TifoXRCoreWebAPI.Controllers
                 created);
         }
 
+        /// <summary>
+        /// POST /api/space/{spaceId}/teleport_table/{tableId}/button
+        /// Creates a button for an existing teleport table using an existing map spot identifier.
+        /// </summary>
+        [HttpPost("{spaceId}/teleport_table/{tableId}/button")]
+        [ProducesResponseType(typeof(ButtonData), StatusCodes.Status201Created)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+        public async Task<ActionResult<ButtonData>> CreateTeleportTableButton(
+            [FromRoute] int spaceId,
+            [FromRoute] int tableId,
+            [FromBody] TeleportTableButtonCreateRequest dto)
+        {
+            if (spaceId <= 0)
+                throw ErrorService.Exception(
+                    ErrorType.Argument,
+                    nameof(CreateTeleportTableButton),
+                    ErrorMessages.Validation.PositiveIntRequired,
+                    paramName: nameof(spaceId),
+                    parameters: new { spaceId, tableId });
+
+            if (tableId <= 0)
+                throw ErrorService.Exception(
+                    ErrorType.Argument,
+                    nameof(CreateTeleportTableButton),
+                    ErrorMessages.Validation.PositiveIntRequired,
+                    paramName: nameof(tableId),
+                    parameters: new { spaceId, tableId });
+
+            if (dto is null)
+                throw ErrorService.Exception(
+                    ErrorType.ArgumentNull,
+                    nameof(CreateTeleportTableButton),
+                    ErrorMessages.Validation.MissingParameter,
+                    paramName: nameof(dto),
+                    parameters: new { spaceId, tableId });
+
+            if (dto.MapSpotId <= 0)
+                throw ErrorService.Exception(
+                    ErrorType.Argument,
+                    nameof(CreateTeleportTableButton),
+                    ErrorMessages.Validation.PositiveIntRequired,
+                    paramName: nameof(dto.MapSpotId),
+                    parameters: new { spaceId, tableId, dto.MapSpotId });
+
+            var created = await _teleportRepository.CreateTeleportTableButtonAsync(spaceId, tableId, dto);
+
+            if (created is null)
+                throw ErrorService.Exception(
+                    ErrorType.NotFound,
+                    nameof(CreateTeleportTableButton),
+                    ErrorMessages.Http.NotFound,
+                    parameters: new { spaceId, tableId, dto.MapSpotId });
+
+            return CreatedAtAction(
+                nameof(GetTeleportTablesBySpace),
+                new { spaceId, tableId },
+                created);
+        }
+
         #endregion
 
         #region PUT

--- a/Models/TeleportTableModel.cs
+++ b/Models/TeleportTableModel.cs
@@ -53,6 +53,14 @@ namespace GMS.TifoXRCoreWebAPI.Models
         public bool IsActive { get; set; }
     }
 
+    public class TeleportTableButtonCreateRequest
+    {
+        public string NameKey { get; set; } = default!;
+        public int MapSpotId { get; set; }
+        public LocalizedPairs? LocalizedPairs { get; set; }
+        public bool IsActive { get; set; }
+    }
+
     public class ButtonUpdateDto
     {
         public int? Id { get; set; }

--- a/Repositories/Interfaces/ITeleportTableRepository.cs
+++ b/Repositories/Interfaces/ITeleportTableRepository.cs
@@ -14,6 +14,7 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
         Task<TeleportTableData> GetTeleportTableBySpaceAsync(int spaceId);
         Task<TeleportTableData> CreateTeleportTableAsync(int spaceId, TeleportTableCreateDto dto);
         Task<TeleportTableData> UpdateTeleportTableAsync(int spaceId, int tableId, TeleportTableUpdateDto dto);
+        Task<ButtonData> CreateTeleportTableButtonAsync(int spaceId, int tableId, TeleportTableButtonCreateRequest dto);
         Task<bool> DeleteTeleportTableAsync(int spaceId, int tableId);
         Task<int> DeleteTeleportTablesBySpaceAsync(int spaceId);
         Task<bool> DeleteTeleportTableButtonAsync(int buttonId, int tableId);

--- a/Repositories/TeleportTableRepository.cs
+++ b/Repositories/TeleportTableRepository.cs
@@ -953,6 +953,46 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
                     }
                 }
 
+                MapSpotData? mapSpotData = null;
+                if (mapSpotId.HasValue)
+                {
+                    const string fetchMapSpot = @"
+                SELECT id, x, y, z
+                  FROM map_spot
+                 WHERE id = @MapSpotId;";
+
+                    await using var mapSpotCmd = _db.CreateCommand(connection, fetchMapSpot);
+                    mapSpotCmd.Transaction = tx;
+                    mapSpotCmd.Parameters.Add(_db.CreateParameter("@MapSpotId", mapSpotId.Value));
+
+                    await using var mapSpotReader = await mapSpotCmd.ExecuteReaderAsync();
+                    if (await mapSpotReader.ReadAsync())
+                    {
+                        var ordinalId = mapSpotReader.GetOrdinal("id");
+                        var ordinalX = mapSpotReader.GetOrdinal("x");
+                        var ordinalY = mapSpotReader.GetOrdinal("y");
+                        var ordinalZ = mapSpotReader.GetOrdinal("z");
+
+                        mapSpotData = new MapSpotData
+                        {
+                            Id = mapSpotReader.IsDBNull(ordinalId) ? mapSpotId.Value : mapSpotReader.GetInt32(ordinalId),
+                            X = mapSpotReader.IsDBNull(ordinalX) ? 0 : mapSpotReader.GetDecimal(ordinalX),
+                            Y = mapSpotReader.IsDBNull(ordinalY) ? 0 : mapSpotReader.GetDecimal(ordinalY),
+                            Z = mapSpotReader.IsDBNull(ordinalZ) ? 0 : mapSpotReader.GetDecimal(ordinalZ)
+                        };
+                    }
+                    else
+                    {
+                        mapSpotData = new MapSpotData
+                        {
+                            Id = mapSpotId.Value,
+                            X = btnDto.MapSpot?.X ?? 0,
+                            Y = btnDto.MapSpot?.Y ?? 0,
+                            Z = btnDto.MapSpot?.Z ?? 0
+                        };
+                    }
+                }
+
                 // 2) Insert button
                 const string insBtn = @"
             INSERT INTO teleport_table_button (table_id, name_key, map_spot_id, is_active)
@@ -1012,15 +1052,7 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
                         Key = btnDto.NameKey ?? string.Empty,
                         Values = new List<LocalizedValue>()
                     },
-                    MapSpot = mapSpotId.HasValue
-                        ? new MapSpotData
-                        {
-                            Id = mapSpotId.Value,
-                            X = btnDto.MapSpot?.X ?? 0,
-                            Y = btnDto.MapSpot?.Y ?? 0,
-                            Z = btnDto.MapSpot?.Z ?? 0
-                        }
-                        : null
+                    MapSpot = mapSpotData
                 };
             }
             catch
@@ -1029,6 +1061,25 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
                     await tx.RollbackAsync();
                 throw;
             }
+        }
+
+        public async Task<ButtonData> CreateTeleportTableButtonAsync(
+        int spaceId,
+        int tableId,
+        TeleportTableButtonCreateRequest dto)
+        {
+            if (dto == null) throw new ArgumentNullException(nameof(dto));
+            if (dto.MapSpotId <= 0) throw new ArgumentOutOfRangeException(nameof(dto.MapSpotId));
+
+            var buttonDto = new ButtonCreateDto
+            {
+                NameKey = dto.NameKey,
+                IsActive = dto.IsActive,
+                LocalizedPairs = dto.LocalizedPairs,
+                MapSpot = new MapSpotData { Id = dto.MapSpotId }
+            };
+
+            return await CreateTeleportTableButtonAsync(spaceId, tableId, buttonDto);
         }
 
         #endregion

--- a/TifoXRCoreWebAPI.Tests/Controllers/TeleportTableControllerTests.cs
+++ b/TifoXRCoreWebAPI.Tests/Controllers/TeleportTableControllerTests.cs
@@ -194,6 +194,91 @@ namespace GMS.TifoXRCoreWebAPI.Tests.Controllers
             createdAt.Value.Should().BeEquivalentTo(created);
         }
 
+        /// <summary>
+        /// Ensures CreateTeleportTableButton validates route parameters and payload.
+        /// </summary>
+        [Theory]
+        [InlineData(0, 1, true)]
+        [InlineData(-1, 1, true)]
+        [InlineData(1, 0, true)]
+        [InlineData(1, -5, true)]
+        [InlineData(1, 1, false)]
+        public async Task CreateButton_Throws_OnInvalidInput(int spaceId, int tableId, bool hasDto)
+        {
+            var dto = hasDto ? new TeleportTableButtonCreateRequest { NameKey = "btn", MapSpotId = 5, IsActive = true } : null;
+
+            if (hasDto)
+            {
+                await Assert.ThrowsAsync<ArgumentException>(
+                    () => sut.CreateTeleportTableButton(spaceId, tableId, dto!)
+                );
+            }
+            else
+            {
+                await Assert.ThrowsAsync<ArgumentNullException>(
+                    () => sut.CreateTeleportTableButton(spaceId, tableId, dto!)
+                );
+            }
+        }
+
+        /// <summary>
+        /// Ensures mapSpotId validation for CreateTeleportTableButton.
+        /// </summary>
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-10)]
+        public async Task CreateButton_Throws_OnInvalidMapSpotId(int mapSpotId)
+        {
+            var dto = new TeleportTableButtonCreateRequest { NameKey = "btn", MapSpotId = mapSpotId, IsActive = true };
+
+            await Assert.ThrowsAsync<ArgumentException>(
+                () => sut.CreateTeleportTableButton(1, 2, dto)
+            );
+        }
+
+        /// <summary>
+        /// Ensures CreateTeleportTableButton returns CreatedAtAction when repository succeeds.
+        /// </summary>
+        [Fact]
+        public async Task CreateButton_ReturnsCreated_OnSuccess()
+        {
+            var dto = new TeleportTableButtonCreateRequest
+            {
+                NameKey = "btn.submit",
+                MapSpotId = 10,
+                IsActive = true
+            };
+
+            var created = new ButtonData { Id = 55, NameKey = "btn.submit" };
+
+            repo.Setup(r => r.CreateTeleportTableButtonAsync(3, 4, dto))
+                .ReturnsAsync(created);
+
+            var result = await sut.CreateTeleportTableButton(3, 4, dto);
+
+            var createdAt = result.Result.Should().BeOfType<CreatedAtActionResult>().Subject;
+            createdAt.ActionName.Should().Be(nameof(TeleportTableController.GetTeleportTablesBySpace));
+            createdAt.RouteValues!["spaceId"].Should().Be(3);
+            createdAt.RouteValues!["tableId"].Should().Be(4);
+            createdAt.Value.Should().BeEquivalentTo(created);
+        }
+
+        /// <summary>
+        /// Ensures CreateTeleportTableButton propagates not-found semantics when repository returns null.
+        /// </summary>
+        [Fact]
+        public async Task CreateButton_ThrowsNotFound_WhenRepositoryReturnsNull()
+        {
+            var dto = new TeleportTableButtonCreateRequest { NameKey = "btn", MapSpotId = 7, IsActive = true };
+
+            repo.Setup(r => r.CreateTeleportTableButtonAsync(2, 3, dto))
+                .ReturnsAsync((ButtonData?)null);
+
+            await Assert.ThrowsAsync<ResourceNotFoundException>(
+                () => sut.CreateTeleportTableButton(2, 3, dto)
+            );
+        }
+
         #endregion
 
         #region PUT

--- a/TifoXRCoreWebAPI.Tests/Repositories/TeleportTableRepositoryTests.cs
+++ b/TifoXRCoreWebAPI.Tests/Repositories/TeleportTableRepositoryTests.cs
@@ -869,6 +869,76 @@ namespace GMS.TifoXRCoreWebAPI.Tests.Repositories
             fakeDb.Rollbacks.Should().Be(0);
         }
 
+        /// <summary>
+        /// Creates a button using the simplified DTO with an existing map spot id.
+        /// Ensures the returned button includes hydrated map spot coordinates.
+        /// </summary>
+        [Fact]
+        public async Task CreateButton_Request_UsesExistingMapSpotId()
+        {
+            // Arrange
+            var fakeDb = new FakeDbProvider(
+                () => new DataTable().CreateDataReader(),
+                scalarResults: new Queue<object?>(new object?[] { 901 })
+            );
+
+            fakeDb.EnqueueReader(() => MapSpotRow(777, 4.4m, 5.5m, 6.6m));
+
+            var sut = BuildRepo(fakeDb);
+            var request = new TeleportTableButtonCreateRequest
+            {
+                NameKey = "btn.request",
+                MapSpotId = 777,
+                IsActive = true,
+                LocalizedPairs = new LocalizedPairs
+                {
+                    Key = "btn.request",
+                    Values = new List<LocalizedValue>
+                    {
+                        new() { LocaleId = "en-US", Value = "Request" }
+                    }
+                }
+            };
+
+            // Act
+            var created = await sut.CreateTeleportTableButtonAsync(12, 34, request);
+
+            // Assert
+            created.Id.Should().Be(901);
+            created.NameKey.Should().Be("btn.request");
+            created.MapSpot.Should().NotBeNull();
+            created.MapSpot!.Id.Should().Be(777);
+            created.MapSpot.X.Should().Be(4.4m);
+            created.MapSpot.Y.Should().Be(5.5m);
+            created.MapSpot.Z.Should().Be(6.6m);
+            created.LocalizedPairs!.Values.Should().ContainSingle(v => v.LocaleId == "en-US" && v.Value == "Request");
+        }
+
+        /// <summary>
+        /// Guard: MapSpotId must be positive when using the simplified DTO overload.
+        /// </summary>
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-5)]
+        public async Task CreateButton_Request_Throws_OnInvalidMapSpotId(int mapSpotId)
+        {
+            // Arrange
+            var fakeDb = new FakeDbProvider(() => new DataTable().CreateDataReader());
+            var sut = BuildRepo(fakeDb);
+            var request = new TeleportTableButtonCreateRequest
+            {
+                NameKey = "btn.invalid",
+                MapSpotId = mapSpotId,
+                IsActive = true
+            };
+
+            // Act
+            var act = async () => await sut.CreateTeleportTableButtonAsync(1, 2, request);
+
+            // Assert
+            await act.Should().ThrowAsync<ArgumentOutOfRangeException>();
+        }
+
         #endregion
 
         #region PUT TESTS
@@ -883,6 +953,20 @@ namespace GMS.TifoXRCoreWebAPI.Tests.Repositories
             var t = new DataTable();
             t.Columns.Add("locale_id", typeof(string));
             foreach (var loc in locales) t.Rows.Add(loc);
+            return t.CreateDataReader();
+        }
+
+        /// <summary>
+        /// Creates a reader yielding a single map_spot row with provided coordinates.
+        /// </summary>
+        private static DbDataReader MapSpotRow(int id, decimal x, decimal y, decimal z)
+        {
+            var t = new DataTable();
+            t.Columns.Add("id", typeof(int));
+            t.Columns.Add("x", typeof(decimal));
+            t.Columns.Add("y", typeof(decimal));
+            t.Columns.Add("z", typeof(decimal));
+            t.Rows.Add(id, x, y, z);
             return t.CreateDataReader();
         }
 


### PR DESCRIPTION
## Summary
- add a dedicated endpoint that creates teleport table buttons bound to an existing map spot id
- extend repository and DTO support so button creation only requires a mapSpotId while hydrating map spot data from storage
- expand controller and repository unit tests to cover the new endpoint, validation paths, and repository helper logic

## Testing
- dotnet test *(fails: `dotnet` not available in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_6908b3020f8c83298aff33cc4866460d