### PR TITLE
Refactor repositories to use IDbProvider and SQL Server syntax

### DIFF
--- a/Repositories/BoothActivityRepository.cs
+++ b/Repositories/BoothActivityRepository.cs
@@ -5,15 +5,14 @@
 // <date>07/28/2025</date>
 // <summary>Class to handle booth activity SQL side</summary>
 
-using MySqlConnector;
-//
 using GMS.TifoXRCoreWebAPI.Models;
+using GMS.TifoXRCoreWebAPI.Utilities.Infrastructure;
 
 namespace GMS.TifoXRCoreWebAPI.Repositories
 {
-    public class BoothActivityRepository(IConfiguration configuration) : IBoothActivityRepository
+    public class BoothActivityRepository(IDbProvider db) : IBoothActivityRepository
     {
-        private readonly string _connectionString = configuration.GetConnectionString("DefaultConnection");
+        private readonly IDbProvider _db = db;
 
         public async Task<List<BoothActivity>> AddUserBoothActivitiesAsync(List<BoothActivity> boothActivityList)
         {
@@ -22,8 +21,7 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
 
             var createdRecords = new List<BoothActivity>();
 
-            await using var conn = new MySqlConnection(_connectionString);
-            await conn.OpenAsync();
+            await using var conn = await _db.OpenConnectionAsync();
             await using var tx = await conn.BeginTransactionAsync();
 
             try
@@ -38,15 +36,15 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
 
                 foreach (var act in boothActivityList)
                 {
-                    await using var cmd = new MySqlCommand(insertSql, conn, tx);
-                    cmd.Parameters.AddWithValue("@BoothId", act.BoothId);
-                    cmd.Parameters.AddWithValue("@UserId", act.UserId);
-                    cmd.Parameters.AddWithValue("@ExitCode", act.ExitCode);
-                    cmd.Parameters.AddWithValue("@BoothNameKey", act.BoothNameKey);
-                    cmd.Parameters.AddWithValue("@SessionId", act.SessionId);
-                    cmd.Parameters.AddWithValue("@EntryDatetime", act.EntryDatetime);
-                    cmd.Parameters.AddWithValue("@SessionDuration", act.SessionDuration);
-                    cmd.Parameters.AddWithValue("@ExitDatetime", (object?)act.ExitDatetime ?? DBNull.Value);
+                    await using var cmd = _db.CreateCommand(conn, insertSql, tx);
+                    cmd.Parameters.Add(_db.CreateParameter("@BoothId", act.BoothId));
+                    cmd.Parameters.Add(_db.CreateParameter("@UserId", act.UserId));
+                    cmd.Parameters.Add(_db.CreateParameter("@ExitCode", act.ExitCode));
+                    cmd.Parameters.Add(_db.CreateParameter("@BoothNameKey", act.BoothNameKey));
+                    cmd.Parameters.Add(_db.CreateParameter("@SessionId", act.SessionId));
+                    cmd.Parameters.Add(_db.CreateParameter("@EntryDatetime", act.EntryDatetime));
+                    cmd.Parameters.Add(_db.CreateParameter("@SessionDuration", act.SessionDuration));
+                    cmd.Parameters.Add(_db.CreateParameter("@ExitDatetime", act.ExitDatetime));
 
                     await cmd.ExecuteNonQueryAsync();
 

--- a/Repositories/EntityRepository.cs
+++ b/Repositories/EntityRepository.cs
@@ -5,36 +5,29 @@
 // <date>07/28/2025</date>
 // <summary>Class to handle entity SQL side</summary>
 
-using MySqlConnector;
-using System.Data;
+using System.Data.Common;
 //
 using GMS.TifoXRCoreWebAPI.Models;
 using GMS.TifoXRCoreWebAPI.Models.Common;
+using GMS.TifoXRCoreWebAPI.Utilities.Infrastructure;
 
 namespace GMS.TifoXRCoreWebAPI.Repositories
 {
-    public sealed class EntityRepository : IEntityRepository
+    public sealed class EntityRepository(IDbProvider db) : IEntityRepository
     {
-        private readonly string _connStr;
-
-        public EntityRepository(IConfiguration cfg)
-        {
-            _connStr = cfg.GetConnectionString("DefaultConnection");
-        }
+        private readonly IDbProvider _db = db ?? throw new ArgumentNullException(nameof(db));
 
         // GET
         public async Task<EntityData> GetByIdAsync(int id)
         {
-            await using var conn = new MySqlConnection(_connStr);
-            await conn.OpenAsync();
+            await using var conn = await _db.OpenConnectionAsync();
             return await LoadEntityById(conn, id);
         }
 
         // POST
         public async Task<EntityData> CreateAsync(Entity dto)
         {
-            await using var conn = new MySqlConnection(_connStr);
-            await conn.OpenAsync();
+            await using var conn = await _db.OpenConnectionAsync();
             await using var tx = await conn.BeginTransactionAsync();
 
             try
@@ -49,37 +42,37 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
                             @EntityTypeId, @ParentEntityId,
                             @NameKey, @DescriptionKey,
                             @CreationTime, @ModifiedTime, @ModifiedBy);
-                        SELECT LAST_INSERT_ID();";
+                        SELECT CAST(SCOPE_IDENTITY() AS INT);";
 
                 int newId;
-                await using (var cmd = new MySqlCommand(insertEntitySql, conn, tx))
+                await using (var cmd = _db.CreateCommand(conn, insertEntitySql, tx))
                 {
-                    cmd.Parameters.AddWithValue("@EntityTypeId", dto.EntityTypeId);
-                    cmd.Parameters.AddWithValue("@ParentEntityId", (object?)dto.ParentEntityId ?? DBNull.Value);
-                    cmd.Parameters.AddWithValue("@NameKey", dto.LocalizedPairs.Key);
-                    cmd.Parameters.AddWithValue(
+                    cmd.Parameters.Add(_db.CreateParameter("@EntityTypeId", dto.EntityTypeId));
+                    cmd.Parameters.Add(_db.CreateParameter("@ParentEntityId", dto.ParentEntityId));
+                    cmd.Parameters.Add(_db.CreateParameter("@NameKey", dto.LocalizedPairs.Key));
+                    cmd.Parameters.Add(_db.CreateParameter(
                         "@DescriptionKey",
                         string.IsNullOrWhiteSpace(dto.LocalizedDescription?.Key)
                             ? DBNull.Value
-                            : dto.LocalizedDescription!.Key);
-                    cmd.Parameters.AddWithValue("@CreationTime", DateTime.UtcNow);
-                    cmd.Parameters.AddWithValue("@ModifiedTime", DateTime.UtcNow);
-                    cmd.Parameters.AddWithValue("@ModifiedBy", "system");
+                            : dto.LocalizedDescription!.Key));
+                    cmd.Parameters.Add(_db.CreateParameter("@CreationTime", DateTime.UtcNow));
+                    cmd.Parameters.Add(_db.CreateParameter("@ModifiedTime", DateTime.UtcNow));
+                    cmd.Parameters.Add(_db.CreateParameter("@ModifiedBy", "system"));
                     newId = Convert.ToInt32(await cmd.ExecuteScalarAsync());
                 }
 
                 // insert into i18n
                 const string insertI18nSql = @"
-                        INSERT INTO i18n (`key`, locale_id, value, space_id)
+                        INSERT INTO i18n ([key], locale_id, [value], space_id)
                         VALUES (@Key, @LocaleId, @Value, @SpaceId);";
 
                 foreach (var loc in dto.LocalizedPairs.Values)
                 {
-                    await using var nameCmd = new MySqlCommand(insertI18nSql, conn, tx);
-                    nameCmd.Parameters.AddWithValue("@Key", dto.LocalizedPairs.Key);
-                    nameCmd.Parameters.AddWithValue("@LocaleId", loc.LocaleId);
-                    nameCmd.Parameters.AddWithValue("@Value", (object?)loc.Value ?? DBNull.Value);
-                    nameCmd.Parameters.AddWithValue("@SpaceId", dto.SpaceId);
+                    await using var nameCmd = _db.CreateCommand(conn, insertI18nSql, tx);
+                    nameCmd.Parameters.Add(_db.CreateParameter("@Key", dto.LocalizedPairs.Key));
+                    nameCmd.Parameters.Add(_db.CreateParameter("@LocaleId", loc.LocaleId));
+                    nameCmd.Parameters.Add(_db.CreateParameter("@Value", loc.Value));
+                    nameCmd.Parameters.Add(_db.CreateParameter("@SpaceId", dto.SpaceId));
                     await nameCmd.ExecuteNonQueryAsync();
                 }
 
@@ -87,11 +80,11 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
                 {
                     foreach (var loc in dto.LocalizedDescription.Values)
                     {
-                        await using var descCmd = new MySqlCommand(insertI18nSql, conn, tx);
-                        descCmd.Parameters.AddWithValue("@Key", dto.LocalizedDescription.Key);
-                        descCmd.Parameters.AddWithValue("@LocaleId", loc.LocaleId);
-                        descCmd.Parameters.AddWithValue("@Value", (object?)loc.Value ?? DBNull.Value);
-                        descCmd.Parameters.AddWithValue("@SpaceId", dto.SpaceId);
+                        await using var descCmd = _db.CreateCommand(conn, insertI18nSql, tx);
+                        descCmd.Parameters.Add(_db.CreateParameter("@Key", dto.LocalizedDescription.Key));
+                        descCmd.Parameters.Add(_db.CreateParameter("@LocaleId", loc.LocaleId));
+                        descCmd.Parameters.Add(_db.CreateParameter("@Value", loc.Value));
+                        descCmd.Parameters.Add(_db.CreateParameter("@SpaceId", dto.SpaceId));
                         await descCmd.ExecuteNonQueryAsync();
                     }
                 }
@@ -109,8 +102,7 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
         // PUT
         public async Task<EntityData> UpdateAsync(int id, Entity dto)
         {
-            await using var conn = new MySqlConnection(_connStr);
-            await conn.OpenAsync();
+            await using var conn = await _db.OpenConnectionAsync();
             await using var tx = await conn.BeginTransactionAsync();
 
             try
@@ -126,19 +118,19 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
                             modified_by      = @ModifiedBy
                         WHERE id = @Id;";
 
-                await using (var cmd = new MySqlCommand(updateEntitySql, conn, tx))
+                await using (var cmd = _db.CreateCommand(conn, updateEntitySql, tx))
                 {
-                    cmd.Parameters.AddWithValue("@Id", id);
-                    cmd.Parameters.AddWithValue("@EntityTypeId", dto.EntityTypeId);
-                    cmd.Parameters.AddWithValue("@ParentEntityId", (object?)dto.ParentEntityId ?? DBNull.Value);
-                    cmd.Parameters.AddWithValue("@NameKey", dto.LocalizedPairs.Key);
-                    cmd.Parameters.AddWithValue(
+                    cmd.Parameters.Add(_db.CreateParameter("@Id", id));
+                    cmd.Parameters.Add(_db.CreateParameter("@EntityTypeId", dto.EntityTypeId));
+                    cmd.Parameters.Add(_db.CreateParameter("@ParentEntityId", dto.ParentEntityId));
+                    cmd.Parameters.Add(_db.CreateParameter("@NameKey", dto.LocalizedPairs.Key));
+                    cmd.Parameters.Add(_db.CreateParameter(
                         "@DescriptionKey",
                         string.IsNullOrWhiteSpace(dto.LocalizedDescription?.Key)
                             ? DBNull.Value
-                            : dto.LocalizedDescription!.Key);
-                    cmd.Parameters.AddWithValue("@ModifiedTime", DateTime.UtcNow);
-                    cmd.Parameters.AddWithValue("@ModifiedBy", "system");
+                            : dto.LocalizedDescription!.Key));
+                    cmd.Parameters.Add(_db.CreateParameter("@ModifiedTime", DateTime.UtcNow));
+                    cmd.Parameters.Add(_db.CreateParameter("@ModifiedBy", "system"));
 
                     if (await cmd.ExecuteNonQueryAsync() == 0)
                     {
@@ -150,30 +142,30 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
                 // upsert i18n rows
                 const string updateI18nSql = @"
                         UPDATE i18n
-                        SET value = @Value
-                        WHERE `key` = @Key AND locale_id = @LocaleId AND space_id = @SpaceId;";
+                        SET [value] = @Value
+                        WHERE [key] = @Key AND locale_id = @LocaleId AND space_id = @SpaceId;";
 
                 const string insertI18nSql = @"
-                        INSERT INTO i18n (`key`, locale_id, value, space_id)
+                        INSERT INTO i18n ([key], locale_id, [value], space_id)
                         VALUES (@Key, @LocaleId, @Value, @SpaceId);";
 
                 async Task UpsertAsync(LocalizedPairs ln)
                 {
                     foreach (var loc in ln.Values)
                     {
-                        await using var uCmd = new MySqlCommand(updateI18nSql, conn, tx);
-                        uCmd.Parameters.AddWithValue("@Key", ln.Key);
-                        uCmd.Parameters.AddWithValue("@LocaleId", loc.LocaleId);
-                        uCmd.Parameters.AddWithValue("@Value", (object?)loc.Value ?? DBNull.Value);
-                        uCmd.Parameters.AddWithValue("@SpaceId", dto.SpaceId);
+                        await using var uCmd = _db.CreateCommand(conn, updateI18nSql, tx);
+                        uCmd.Parameters.Add(_db.CreateParameter("@Key", ln.Key));
+                        uCmd.Parameters.Add(_db.CreateParameter("@LocaleId", loc.LocaleId));
+                        uCmd.Parameters.Add(_db.CreateParameter("@Value", loc.Value));
+                        uCmd.Parameters.Add(_db.CreateParameter("@SpaceId", dto.SpaceId));
 
                         if (await uCmd.ExecuteNonQueryAsync() == 0)
                         {
-                            await using var iCmd = new MySqlCommand(insertI18nSql, conn, tx);
-                            iCmd.Parameters.AddWithValue("@Key", ln.Key);
-                            iCmd.Parameters.AddWithValue("@LocaleId", loc.LocaleId);
-                            iCmd.Parameters.AddWithValue("@Value", (object?)loc.Value ?? DBNull.Value);
-                            iCmd.Parameters.AddWithValue("@SpaceId", dto.SpaceId);
+                            await using var iCmd = _db.CreateCommand(conn, insertI18nSql, tx);
+                            iCmd.Parameters.Add(_db.CreateParameter("@Key", ln.Key));
+                            iCmd.Parameters.Add(_db.CreateParameter("@LocaleId", loc.LocaleId));
+                            iCmd.Parameters.Add(_db.CreateParameter("@Value", loc.Value));
+                            iCmd.Parameters.Add(_db.CreateParameter("@SpaceId", dto.SpaceId));
                             await iCmd.ExecuteNonQueryAsync();
                         }
                     }
@@ -195,7 +187,7 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
         }
 
         // Helper Function
-        private static async Task<EntityData> LoadEntityById(MySqlConnection conn, int entityId)
+        private async Task<EntityData> LoadEntityById(DbConnection conn, int entityId)
         {
             const string sql = @"
                     SELECT
@@ -208,69 +200,89 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
                         e.modified_time,
                         e.modified_by,
                         i_name.locale_id AS name_locale_id,
-                        i_name.value     AS name_value,
-                        i_desc.value     AS desc_value
+                        i_name.[value]   AS name_value,
+                        i_desc.[value]   AS desc_value
                     FROM entity e
                     LEFT JOIN i18n i_name
-                           ON i_name.`key` = e.name_key
+                           ON i_name.[key] = e.name_key
                     LEFT JOIN i18n i_desc
-                           ON i_desc.`key` = e.description_key
+                           ON i_desc.[key] = e.description_key
                           AND i_desc.locale_id = i_name.locale_id
                     WHERE e.id = @EntityId
                     ORDER BY i_name.locale_id;";
 
-            await using var cmd = new MySqlCommand(sql, conn);
-            cmd.Parameters.AddWithValue("@EntityId", entityId);
+            await using var cmd = _db.CreateCommand(conn, sql);
+            cmd.Parameters.Add(_db.CreateParameter("@EntityId", entityId));
 
             await using var rdr = await cmd.ExecuteReaderAsync();
             EntityData entity = null;
             var names = new List<LocalizedValue>();
             var descs = new List<LocalizedValue>();
 
+            bool ordReady = false;
+            int oId = -1, oEntityTypeId = -1, oParentEntityId = -1, oNameKey = -1, oDescriptionKey = -1;
+            int oCreationTime = -1, oModifiedTime = -1, oModifiedBy = -1, oNameLocaleId = -1, oNameValue = -1, oDescValue = -1;
+
             while (await rdr.ReadAsync())
             {
+                if (!ordReady)
+                {
+                    oId = rdr.GetOrdinal("id");
+                    oEntityTypeId = rdr.GetOrdinal("entity_type_id");
+                    oParentEntityId = rdr.GetOrdinal("parent_entity_id");
+                    oNameKey = rdr.GetOrdinal("name_key");
+                    oDescriptionKey = rdr.GetOrdinal("description_key");
+                    oCreationTime = rdr.GetOrdinal("creation_time");
+                    oModifiedTime = rdr.GetOrdinal("modified_time");
+                    oModifiedBy = rdr.GetOrdinal("modified_by");
+                    oNameLocaleId = rdr.GetOrdinal("name_locale_id");
+                    oNameValue = rdr.GetOrdinal("name_value");
+                    oDescValue = rdr.GetOrdinal("desc_value");
+                    ordReady = true;
+                }
+
                 if (entity is null)
                 {
                     entity = new EntityData
                     {
-                        Id = rdr.GetInt32("id"),
-                        EntityTypeId = rdr.GetInt32("entity_type_id"),
-                        ParentEntityId = rdr.IsDBNull("parent_entity_id")
+                        Id = rdr.GetInt32(oId),
+                        EntityTypeId = rdr.GetInt32(oEntityTypeId),
+                        ParentEntityId = rdr.IsDBNull(oParentEntityId)
                             ? null
-                            : rdr.GetInt32("parent_entity_id"),
-                        CreationTime = rdr.GetDateTime("creation_time"),
-                        ModifiedTime = rdr.GetDateTime("modified_time"),
-                        ModifiedBy = rdr.GetString("modified_by"),
+                            : rdr.GetInt32(oParentEntityId),
+                        CreationTime = rdr.GetDateTime(oCreationTime),
+                        ModifiedTime = rdr.GetDateTime(oModifiedTime),
+                        ModifiedBy = rdr.GetString(oModifiedBy),
                         LocalizedPairs = new LocalizedPairs
                         {
-                            Key = rdr.GetString("name_key"),
+                            Key = rdr.GetString(oNameKey),
                             Values = names
                         },
                         LocalizedDescription = new LocalizedPairs
                         {
-                            Key = rdr.GetString("description_key"),
+                            Key = rdr.IsDBNull(oDescriptionKey) ? string.Empty : rdr.GetString(oDescriptionKey),
                             Values = descs
                         }
                     };
                 }
 
-                var locale = rdr.GetString("name_locale_id");
+                var locale = rdr.GetString(oNameLocaleId);
 
-                if (!rdr.IsDBNull(rdr.GetOrdinal("name_value")))
+                if (!rdr.IsDBNull(oNameValue))
                 {
                     names.Add(new LocalizedValue
                     {
                         LocaleId = locale,
-                        Value = rdr.GetString("name_value")
+                        Value = rdr.GetString(oNameValue)
                     });
                 }
 
-                if (!rdr.IsDBNull(rdr.GetOrdinal("desc_value")))
+                if (!rdr.IsDBNull(oDescValue))
                 {
                     descs.Add(new LocalizedValue
                     {
                         LocaleId = locale,
-                        Value = rdr.GetString("desc_value")
+                        Value = rdr.GetString(oDescValue)
                     });
                 }
             }


### PR DESCRIPTION
## Summary
- refactor EntityRepository and BoothActivityRepository to use the shared IDbProvider for database access
- update SQL queries and parameter usage to SQL Server-friendly syntax
- improve entity loading to rely on ordinal lookups for compatibility across providers

## Testing
- dotnet test *(fails: dotnet SDK not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941474ff1b48329a469b65d2af04474)