### PR TITLE
Update SQL syntax for SQL Server

### DIFF
--- a/Repositories/BoothCommentRepository.cs
+++ b/Repositories/BoothCommentRepository.cs
@@ -34,7 +34,7 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
             try
             {
                 // 0) Validate user exists (optional but nicer than FK error)
-                const string sqlUser = @"SELECT 1 FROM `user` WHERE id = @U LIMIT 1;";
+                const string sqlUser = @"SELECT TOP 1 1 FROM [user] WHERE id = @U;";
                 await using (var u = _db.CreateCommand(conn, sqlUser))
                 {
                     u.Transaction = tx;
@@ -45,7 +45,7 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
                 }
 
                 // 1) Fetch predefined comment (must exist and be active)
-                const string sqlPc = @"SELECT comment_key, is_active FROM predefined_comments WHERE id = @Pid LIMIT 1;";
+                const string sqlPc = @"SELECT TOP 1 comment_key, is_active FROM predefined_comments WHERE id = @Pid;";
                 string? commentKey = null;
                 bool pcActive = false;
 
@@ -66,11 +66,10 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
 
                 // 2) Idempotency on (spaceId, userId, predefined_comment_id)
                 const string sqlFindExisting = @"
-SELECT id, is_active, creation_time
+SELECT TOP 1 id, is_active, creation_time
 FROM booth_comment
 WHERE space_id = @S AND user_id = @U AND predefined_comment_id = @Pid
-ORDER BY id
-LIMIT 1;";
+ORDER BY id;";
 
                 int? existingId = null;
                 bool existingActive = false;
@@ -100,7 +99,7 @@ LIMIT 1;";
                     if (!existingActive && dto.IsActive)
                     {
                         // Revive inactive entry
-                        const string sqlUpd = @"UPDATE booth_comment SET is_active = TRUE WHERE id = @Id;";
+                        const string sqlUpd = @"UPDATE booth_comment SET is_active = 1 WHERE id = @Id;";
                         await using var upd = _db.CreateCommand(conn, sqlUpd);
                         upd.Transaction = tx;
                         upd.Parameters.Add(_db.CreateParameter("@Id", existingId.Value));
@@ -123,7 +122,7 @@ LIMIT 1;";
                     // 3) Insert new booth_comment
                     const string sqlIns = @"
 INSERT INTO booth_comment (space_id, user_id, predefined_comment_id, is_active, creation_time, modified_by)
-VALUES (@S, @U, @Pid, @A, NOW(6), 'system');";
+VALUES (@S, @U, @Pid, @A, SYSUTCDATETIME(), 'system');";
                     await using (var ins = _db.CreateCommand(conn, sqlIns))
                     {
                         ins.Transaction = tx;
@@ -134,7 +133,7 @@ VALUES (@S, @U, @Pid, @A, NOW(6), 'system');";
                         await ins.ExecuteNonQueryAsync();
                     }
 
-                    await using (var idCmd = _db.CreateCommand(conn, "SELECT LAST_INSERT_ID();"))
+                    await using (var idCmd = _db.CreateCommand(conn, "SELECT CAST(SCOPE_IDENTITY() AS int);"))
                     {
                         idCmd.Transaction = tx;
                         resultingId = Convert.ToInt32(await idCmd.ExecuteScalarAsync());
@@ -146,7 +145,7 @@ VALUES (@S, @U, @Pid, @A, NOW(6), 'system');";
 
                 // 4) Load localized values for this comment_key in the space
                 var localized = new List<LocalizedValue>();
-                const string sqlI18n = @"SELECT locale_id, value FROM i18n WHERE space_id = @S AND `key` = @K ORDER BY locale_id;";
+                const string sqlI18n = @"SELECT locale_id, value FROM i18n WHERE space_id = @S AND [key] = @K ORDER BY locale_id;";
                 await using (var i18n = _db.CreateCommand(conn, sqlI18n))
                 {
                     i18n.Transaction = tx;
@@ -212,13 +211,13 @@ SELECT
 FROM booth_comment bc
 INNER JOIN predefined_comments pc
         ON pc.id = bc.predefined_comment_id
-LEFT JOIN `user` u
+LEFT JOIN [user] u
        ON u.id = bc.user_id
 WHERE bc.space_id = @S
 {0}
 ORDER BY bc.id;";
 
-            var where = includeInactive ? string.Empty : "AND bc.is_active = TRUE";
+            var where = includeInactive ? string.Empty : "AND bc.is_active = 1";
             var sql = string.Format(sqlBase, where);
 
             await using var conn = await _db.OpenConnectionAsync();
@@ -281,11 +280,11 @@ ORDER BY bc.id;";
             var pNames = keyList.Select((_, i) => $"@k{i}").ToList();
 
             var sqlI18n = $@"
-SELECT `key`, locale_id, value
+SELECT [key], locale_id, value
 FROM i18n
 WHERE space_id = @S
-  AND `key` IN ({string.Join(", ", pNames)})
-ORDER BY `key`, locale_id;";
+  AND [key] IN ({string.Join(", ", pNames)})
+ORDER BY [key], locale_id;";
 
             var map = new Dictionary<string, List<LocalizedValue>>(StringComparer.Ordinal);
 
@@ -349,11 +348,10 @@ ORDER BY `key`, locale_id;";
             {
                 // 0) Load current row (scoped to space)
                 const string sqlLoad = @"
-SELECT bc.id, bc.space_id, bc.user_id, bc.predefined_comment_id, bc.is_active, bc.creation_time, pc.comment_key
+SELECT TOP 1 bc.id, bc.space_id, bc.user_id, bc.predefined_comment_id, bc.is_active, bc.creation_time, pc.comment_key
 FROM booth_comment bc
 INNER JOIN predefined_comments pc ON pc.id = bc.predefined_comment_id
-WHERE bc.id = @Id AND bc.space_id = @S
-LIMIT 1;";
+WHERE bc.id = @Id AND bc.space_id = @S;";
 
                 int currentPid;
                 bool currentActive;
@@ -387,7 +385,7 @@ LIMIT 1;";
                 if (finalPid != currentPid)
                 {
                     // a) Validate target predefined comment exists; must be active if finalActive=true
-                    const string sqlPc = @"SELECT comment_key, is_active FROM predefined_comments WHERE id = @Pid LIMIT 1;";
+                    const string sqlPc = @"SELECT TOP 1 comment_key, is_active FROM predefined_comments WHERE id = @Pid;";
                     string? newKey = null;
                     bool targetActive;
 
@@ -408,10 +406,9 @@ LIMIT 1;";
 
                     // b) Enforce uniqueness for (space, user, newPid) — avoid duplicate row for same selection
                     const string sqlDup = @"
-SELECT id, is_active
+SELECT TOP 1 id, is_active
 FROM booth_comment
-WHERE space_id = @S AND user_id = @U AND predefined_comment_id = @Pid AND id <> @Id
-LIMIT 1;";
+WHERE space_id = @S AND user_id = @U AND predefined_comment_id = @Pid AND id <> @Id;";
 
                     await using (var dup = _db.CreateCommand(conn, sqlDup))
                     {
@@ -453,11 +450,10 @@ LIMIT 1;";
                 }
 
                 // 3) Reload current basics (in case only is_active changed)
-                const string sqlReload = @"
-SELECT bc.id, bc.space_id, bc.user_id, bc.predefined_comment_id, bc.is_active, bc.creation_time
+const string sqlReload = @"
+SELECT TOP 1 bc.id, bc.space_id, bc.user_id, bc.predefined_comment_id, bc.is_active, bc.creation_time
 FROM booth_comment bc
-WHERE bc.id = @Id
-LIMIT 1;";
+WHERE bc.id = @Id;";
                 int resPid;
                 bool resActive;
                 DateTime resCreation;
@@ -474,7 +470,7 @@ LIMIT 1;";
 
                 // 4) Load i18n for the (possibly new) comment key in this space
                 var localized = new List<LocalizedValue>();
-                const string sqlI18n = @"SELECT locale_id, value FROM i18n WHERE space_id = @S AND `key` = @K ORDER BY locale_id;";
+                const string sqlI18n = @"SELECT locale_id, value FROM i18n WHERE space_id = @S AND [key] = @K ORDER BY locale_id;";
                 await using (var i18n = _db.CreateCommand(conn, sqlI18n))
                 {
                     i18n.Transaction = tx;

--- a/Repositories/CharityRepository.cs
+++ b/Repositories/CharityRepository.cs
@@ -66,7 +66,7 @@ VALUES
                 }
 
                 int newId;
-                await using (var idCmd = _db.CreateCommand(conn, "SELECT LAST_INSERT_ID();"))
+                await using (var idCmd = _db.CreateCommand(conn, "SELECT CAST(SCOPE_IDENTITY() AS int);"))
                 {
                     idCmd.Transaction = tx;
                     newId = Convert.ToInt32(await idCmd.ExecuteScalarAsync());
@@ -74,7 +74,7 @@ VALUES
 
                 // (3) Insert i18n rows (space-scoped)
                 const string insI18n = @"
-INSERT INTO i18n (`key`, locale_id, value, space_id)
+INSERT INTO i18n ([key], locale_id, value, space_id)
 VALUES (@Key, @LocaleId, @Value, @SpaceId);";
 
                 if (dto.LocalizedName?.Values != null)
@@ -146,10 +146,10 @@ VALUES (@Key, @LocaleId, @Value, @SpaceId);";
         ml.media_link         AS media_link
     FROM charity c
     LEFT JOIN i18n AS iname
-           ON iname.`key` = c.name_key
+           ON iname.[key] = c.name_key
           AND iname.space_id = @SpaceId
     LEFT JOIN i18n AS idesc
-           ON idesc.`key` = c.description_key
+           ON idesc.[key] = c.description_key
           AND idesc.locale_id = iname.locale_id
           AND idesc.space_id  = iname.space_id
     LEFT JOIN media AS m
@@ -284,7 +284,7 @@ VALUES (@Key, @LocaleId, @Value, @SpaceId);";
             if (spaceId == 0) throw new InvalidOperationException("SpaceId is zero or not set properly.");
 
             string mediaId;
-            await using (var uuidCmd = _db.CreateCommand(conn, "SELECT UUID();"))
+            await using (var uuidCmd = _db.CreateCommand(conn, "SELECT NEWID();"))
             {
                 uuidCmd.Transaction = tx;
                 mediaId = Convert.ToString(await uuidCmd.ExecuteScalarAsync())!;
@@ -560,9 +560,9 @@ WHERE id = @Id AND space_id = @SpaceId;";
                 const string updI18n = @"
 UPDATE i18n
    SET value = @Value
- WHERE `key` = @K AND locale_id = @LocaleId AND space_id = @SpaceId;";
+ WHERE [key] = @K AND locale_id = @LocaleId AND space_id = @SpaceId;";
                 const string insI18n = @"
-INSERT INTO i18n (`key`, locale_id, value, space_id)
+INSERT INTO i18n ([key], locale_id, value, space_id)
 VALUES (@K, @LocaleId, @Value, @SpaceId);";
 
                 if (dto.LocalizedName?.Values != null)
@@ -782,7 +782,7 @@ VALUES (@Mid, @Loc, @Link);";
                 // 4) Delete i18n rows for name/description keys (space-scoped)
                 if (!string.IsNullOrWhiteSpace(nameKey))
                 {
-                    const string delI18n = @"DELETE FROM i18n WHERE `key` = @K AND space_id = @SpaceId;";
+                    const string delI18n = @"DELETE FROM i18n WHERE [key] = @K AND space_id = @SpaceId;";
                     await using var di = _db.CreateCommand(conn, delI18n);
                     di.Transaction = tx;
                     di.Parameters.Add(_db.CreateParameter("@K", nameKey!));
@@ -791,7 +791,7 @@ VALUES (@Mid, @Loc, @Link);";
                 }
                 if (!string.IsNullOrWhiteSpace(descKey))
                 {
-                    const string delI18n = @"DELETE FROM i18n WHERE `key` = @K AND space_id = @SpaceId;";
+                    const string delI18n = @"DELETE FROM i18n WHERE [key] = @K AND space_id = @SpaceId;";
                     await using var di = _db.CreateCommand(conn, delI18n);
                     di.Transaction = tx;
                     di.Parameters.Add(_db.CreateParameter("@K", descKey!));

--- a/Repositories/PersonalityRepository.cs
+++ b/Repositories/PersonalityRepository.cs
@@ -43,9 +43,9 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
                 ml.media_link             AS media_link
             FROM personality p
             LEFT JOIN i18n AS ic
-                   ON ic.`key` = p.country_name_key
+                   ON ic.[key] = p.country_name_key
             LEFT JOIN i18n AS ib
-                   ON ib.`key` = p.bio_data_key
+                   ON ib.[key] = p.bio_data_key
                   AND ib.locale_id = ic.locale_id
             LEFT JOIN media_localization AS ml
                    ON ml.media_id = p.media_id
@@ -213,7 +213,7 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
                 }
 
                 int newId;
-                await using (var idCmd = _db.CreateCommand(conn, "SELECT LAST_INSERT_ID();"))
+                await using (var idCmd = _db.CreateCommand(conn, "SELECT CAST(SCOPE_IDENTITY() AS int);"))
                 {
                     idCmd.Transaction = tx;
                     newId = Convert.ToInt32(await idCmd.ExecuteScalarAsync());
@@ -221,7 +221,7 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
 
                 // 3) Insert i18n for country and bio (space-scoped)
                 const string insertI18n = @"
-                INSERT INTO i18n (`key`, locale_id, value, space_id)
+                INSERT INTO i18n ([key], locale_id, value, space_id)
                 VALUES (@Key, @LocaleId, @Value, @SpaceId);";
 
                 if (dto.LocalizedCountry?.Values != null)
@@ -276,7 +276,7 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
 
             // 1) Get a new UUID from the DB (MySQL)
             string mediaId;
-            await using (var uuidCmd = _db.CreateCommand(conn, "SELECT UUID();"))
+            await using (var uuidCmd = _db.CreateCommand(conn, "SELECT NEWID();"))
             {
                 uuidCmd.Transaction = tx;
                 var o = await uuidCmd.ExecuteScalarAsync();
@@ -371,9 +371,9 @@ WHERE id = @Id;";
                 const string updI18n = @"
 UPDATE i18n
    SET value = @Value
- WHERE `key` = @NameKey AND locale_id = @LocaleId AND space_id = @SpaceId;";
+ WHERE [key] = @NameKey AND locale_id = @LocaleId AND space_id = @SpaceId;";
                 const string insI18n = @"
-INSERT INTO i18n (`key`, locale_id, value, space_id)
+INSERT INTO i18n ([key], locale_id, value, space_id)
 VALUES (@NameKey, @LocaleId, @Value, @SpaceId);";
 
                 if (dto.LocalizedCountry?.Values != null)
@@ -582,7 +582,7 @@ VALUES (@Id, @MediaId, @LocaleId, @MediaLink);";
                 // 2) Delete i18n rows for the keys (no space filter)
                 if (!string.IsNullOrWhiteSpace(countryKey))
                 {
-                    const string delI18nCountry = "DELETE FROM i18n WHERE `key` = @Key;";
+                    const string delI18nCountry = "DELETE FROM i18n WHERE [key] = @Key;";
                     await using var c1 = _db.CreateCommand(conn, delI18nCountry);
                     c1.Transaction = tx;
                     c1.Parameters.Add(_db.CreateParameter("@Key", countryKey!));
@@ -591,7 +591,7 @@ VALUES (@Id, @MediaId, @LocaleId, @MediaLink);";
 
                 if (!string.IsNullOrWhiteSpace(bioKey))
                 {
-                    const string delI18nBio = "DELETE FROM i18n WHERE `key` = @Key;";
+                    const string delI18nBio = "DELETE FROM i18n WHERE [key] = @Key;";
                     await using var c2 = _db.CreateCommand(conn, delI18nBio);
                     c2.Transaction = tx;
                     c2.Parameters.Add(_db.CreateParameter("@Key", bioKey!));

--- a/Repositories/PredefinedCommentRepository.cs
+++ b/Repositories/PredefinedCommentRepository.cs
@@ -34,12 +34,12 @@ SELECT
     i.value
 FROM predefined_comments pc
 LEFT JOIN i18n i
-       ON i.`key` = pc.comment_key
+       ON i.[key] = pc.comment_key
       AND i.space_id = @SpaceId
 {0}
 ORDER BY pc.id, i.locale_id;";
 
-            var where = includeInactive ? "" : "WHERE pc.is_active = TRUE";
+            var where = includeInactive ? "" : "WHERE pc.is_active = 1";
             var sql = string.Format(sqlBase, where);
 
             await using var conn = await _db.OpenConnectionAsync();
@@ -125,7 +125,7 @@ ORDER BY pc.id, i.locale_id;";
                 // 1) Insert predefined_comments
                 const string sqlIns = @"
 INSERT INTO predefined_comments (comment_key, is_active, creation_time, modified_by)
-VALUES (@K, @A, NOW(6), 'system');";
+VALUES (@K, @A, SYSUTCDATETIME(), 'system');";
                 await using (var insCmd = _db.CreateCommand(conn, sqlIns))
                 {
                     insCmd.Transaction = tx;
@@ -135,7 +135,7 @@ VALUES (@K, @A, NOW(6), 'system');";
                 }
 
                 int newId;
-                await using (var idCmd = _db.CreateCommand(conn, "SELECT LAST_INSERT_ID();"))
+                await using (var idCmd = _db.CreateCommand(conn, "SELECT CAST(SCOPE_IDENTITY() AS int);"))
                 {
                     idCmd.Transaction = tx;
                     newId = Convert.ToInt32(await idCmd.ExecuteScalarAsync());
@@ -178,7 +178,7 @@ SELECT locale_id
                 if (values.Count > 0)
                 {
                     const string sqlInsI18n = @"
-INSERT INTO i18n (`key`, locale_id, value, space_id)
+INSERT INTO i18n ([key], locale_id, value, space_id)
 VALUES (@K, @L, @V, @S);";
 
                     foreach (var v in values)
@@ -251,10 +251,9 @@ VALUES (@K, @L, @V, @S);";
             {
                 // 0) Fetch comment_key and current fields by id
                 const string sqlFind = @"
-SELECT comment_key, is_active, creation_time
+SELECT TOP 1 comment_key, is_active, creation_time
 FROM predefined_comments
-WHERE id = @Id
-LIMIT 1;";
+WHERE id = @Id;";
                 string? commentKey = null;
                 DateTime creation = default;
                 bool isActive = true;
@@ -324,9 +323,9 @@ SELECT locale_id
                     const string sqlUpdateI18n = @"
 UPDATE i18n
    SET value = @V
- WHERE `key` = @K AND locale_id = @L AND space_id = @S;";
+ WHERE [key] = @K AND locale_id = @L AND space_id = @S;";
                     const string sqlInsertI18n = @"
-INSERT INTO i18n (`key`, locale_id, value, space_id)
+INSERT INTO i18n ([key], locale_id, value, space_id)
 VALUES (@K, @L, @V, @S);";
 
                     foreach (var v in incoming)
@@ -376,7 +375,7 @@ SELECT
     i.value
 FROM predefined_comments pc
 LEFT JOIN i18n i
-       ON i.`key` = pc.comment_key
+       ON i.[key] = pc.comment_key
       AND i.space_id = @SpaceId
 WHERE pc.comment_key = @K
 ORDER BY i.locale_id;";
@@ -441,7 +440,7 @@ ORDER BY i.locale_id;";
             try
             {
                 // 0) Load comment_key (and existence)
-                const string sqlFind = @"SELECT comment_key FROM predefined_comments WHERE id = @Id LIMIT 1;";
+                const string sqlFind = @"SELECT TOP 1 comment_key FROM predefined_comments WHERE id = @Id;";
                 string? commentKey = null;
                 await using (var find = _db.CreateCommand(conn, sqlFind))
                 {
@@ -476,7 +475,7 @@ ORDER BY i.locale_id;";
                     }
 
                     // 2) Delete i18n for ALL spaces for this key
-                    const string sqlDelI18nAll = @"DELETE FROM i18n WHERE `key` = @K;";
+                    const string sqlDelI18nAll = @"DELETE FROM i18n WHERE [key] = @K;";
                     await using (var di = _db.CreateCommand(conn, sqlDelI18nAll))
                     {
                         di.Transaction = tx;
@@ -499,7 +498,7 @@ ORDER BY i.locale_id;";
                 else
                 {
                     // SOFT DELETE: mark inactive
-                    const string sqlSoft = @"UPDATE predefined_comments SET is_active = FALSE WHERE id = @Id;";
+                    const string sqlSoft = @"UPDATE predefined_comments SET is_active = 0 WHERE id = @Id;";
                     await using (var sd = _db.CreateCommand(conn, sqlSoft))
                     {
                         sd.Transaction = tx;
@@ -510,7 +509,7 @@ ORDER BY i.locale_id;";
                     if (deleteI18nForSpace)
                     {
                         // Remove i18n only for this space to "unregister" in that context
-                        const string sqlDelI18nSpace = @"DELETE FROM i18n WHERE `key` = @K AND space_id = @S;";
+                        const string sqlDelI18nSpace = @"DELETE FROM i18n WHERE [key] = @K AND space_id = @S;";
                         await using (var ds = _db.CreateCommand(conn, sqlDelI18nSpace))
                         {
                             ds.Transaction = tx;

--- a/Repositories/SpaceRepository.cs
+++ b/Repositories/SpaceRepository.cs
@@ -34,7 +34,7 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
             i.value
         FROM space s
         LEFT JOIN i18n i 
-            ON i.`key` = s.description_key 
+            ON i.[key] = s.description_key
            AND i.space_id = s.id
         WHERE s.id = @Id
         ORDER BY i.locale_id;";
@@ -150,7 +150,7 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
 
                 // 2) Get new id
                 int newId;
-                await using (var idCmd = _db.CreateCommand(conn, "SELECT LAST_INSERT_ID();"))
+                await using (var idCmd = _db.CreateCommand(conn, "SELECT CAST(SCOPE_IDENTITY() AS int);"))
                 {
                     idCmd.Transaction = tx;
                     newId = Convert.ToInt32(await idCmd.ExecuteScalarAsync());
@@ -158,7 +158,7 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
 
                 // 3) Insert localized descriptions
                 const string insertI18n = @"
-            INSERT INTO i18n (`key`, locale_id, value, space_id)
+            INSERT INTO i18n ([key], locale_id, value, space_id)
             VALUES (@Key, @LocaleId, @Value, @SpaceId);";
 
                 if (spaceDto.LocalizedDescription?.Values != null)
@@ -236,9 +236,9 @@ UPDATE space
                 const string updateI18n = @"
 UPDATE i18n
    SET value = @Value
- WHERE `key` = @Key AND locale_id = @LocaleId AND space_id = @SpaceId;";
+ WHERE [key] = @Key AND locale_id = @LocaleId AND space_id = @SpaceId;";
                 const string insertI18n = @"
-INSERT INTO i18n (`key`, locale_id, value, space_id)
+INSERT INTO i18n ([key], locale_id, value, space_id)
 VALUES (@Key, @LocaleId, @Value, @SpaceId);";
 
                 if (spaceDto.LocalizedDescription?.Values != null)

--- a/Repositories/Sql/LookupSql.cs
+++ b/Repositories/Sql/LookupSql.cs
@@ -62,7 +62,7 @@ namespace GMS.TifoXRCoreWebAPI.Repositories.Sql
 
         public const string ContextParameters = @"
             SELECT cp.id,
-                   cp.`key` AS `Key`,
+                   cp.[key] AS [Key],
                    cp.source AS Source,
                    cp.path AS Path,
                    cp.re_path_type_id AS RePathTypeId,
@@ -83,8 +83,8 @@ namespace GMS.TifoXRCoreWebAPI.Repositories.Sql
             SELECT etp.id,
                    etp.re_event_type_id AS EventTypeId,
                    etp.parameter_id AS ParameterId,
-                   cp.`key` AS ParameterKey,
-                   (etp.is_required + 0) AS IsRequired,
+                   cp.[key] AS ParameterKey,
+                   CAST(etp.is_required AS int) AS IsRequired,
                    etp.default_value_json AS DefaultValueJson
             FROM re_event_type_parameter etp
             JOIN re_context_parameter cp ON cp.id = etp.parameter_id

--- a/Repositories/Sql/OrderSql.cs
+++ b/Repositories/Sql/OrderSql.cs
@@ -14,7 +14,7 @@ namespace GMS.TifoXRCoreWebAPI.Repositories.SQL
             SELECT id, user_id, space_id, transaction_type_id, currency_id, status_id,
                    total_gross_amount, total_discount_amount, total_tax_amount, total_fee_amount, total_net_amount,
                    change_reason, original_order_id, session_id, gateway_preferred_id, order_datetime, remarks
-            FROM `order` WHERE id=@OrderId AND space_id=@SpaceId;";
+            FROM [order] WHERE id=@OrderId AND space_id=@SpaceId;";
 
         internal const string Order_SelectLines = @"
             SELECT id, item_type_id, item_ref_id, entity_id, shop_id, quantity, unit_amount, currency_id, metadata
@@ -56,20 +56,19 @@ namespace GMS.TifoXRCoreWebAPI.Repositories.SQL
             ORDER BY refund_datetime;";
 
         internal const string Order_Insert = @"
-                    INSERT INTO `order`
+                    INSERT INTO [order]
                     (id, user_id, space_id, transaction_type_id, currency_id, status_id,
                      total_gross_amount, total_discount_amount, change_reason, total_tax_amount, total_fee_amount, total_net_amount,
                      original_order_id, session_id, gateway_preferred_id, order_datetime, remarks, idempotency_key, modified_by)
                     VALUES
                     (@Id, @UserId, @SpaceId, @Trx, @CcyId, @StatusId,
                      @Gross, @Disc, NULL, @Tax, @Fees, @Net,
-                     NULL, @SessionId, @GatewayPreferredId, NOW(6), @Remarks, @IdemKey, @ModBy);";
+                     NULL, @SessionId, @GatewayPreferredId, SYSUTCDATETIME(), @Remarks, @IdemKey, @ModBy);";
 
         internal const string Order_FindExisting = @"
-                    SELECT id, total_net_amount, space_id
-                    FROM `order`
-                    WHERE idempotency_key = @IdemKey
-                    LIMIT 1;";
+                    SELECT TOP 1 id, total_net_amount, space_id
+                    FROM [order]
+                    WHERE idempotency_key = @IdemKey;";
 
         internal const string Order_InsertLine = @"
                     INSERT INTO order_line
@@ -93,26 +92,26 @@ namespace GMS.TifoXRCoreWebAPI.Repositories.SQL
             INSERT INTO payment_charge
             (id, payment_intent_id, status_id, amount_captured, currency_id, provider_charge_id,
              payment_datetime, creation_time, modified_by)
-            VALUES (@Id, @IntentId, @Status, @Amt, @Ccy, @ProvCharge, @PaidAt, NOW(6), @ModBy);";
+            VALUES (@Id, @IntentId, @Status, @Amt, @Ccy, @ProvCharge, @PaidAt, SYSUTCDATETIME(), @ModBy);";
 
         internal const string Intent_FindPendingForOrder = @"
-            SELECT pi.id, pi.status_id, pi.idempotency_key, pi.provider_intent_id,
+            SELECT TOP 1 pi.id, pi.status_id, pi.idempotency_key, pi.provider_intent_id,
                    pi.payment_gateway_id, pi.amount, pi.currency_id
             FROM payment_intent pi
             WHERE pi.order_id=@OrderId
               AND pi.status_id IN (1,2)
               AND (@GatewayId IS NULL OR pi.payment_gateway_id=@GatewayId)
-            ORDER BY pi.creation_time DESC LIMIT 1;";
+            ORDER BY pi.creation_time DESC;";
 
         internal const string Intent_FindByIdem = @"
-            SELECT id, provider_intent_id FROM payment_intent
-            WHERE order_id=@OrderId AND idempotency_key=@Key LIMIT 1;";
+            SELECT TOP 1 id, provider_intent_id FROM payment_intent
+            WHERE order_id=@OrderId AND idempotency_key=@Key;";
 
         internal const string Intent_Insert = @"
             INSERT INTO payment_intent
             (id, order_id, payment_gateway_id, status_id, amount, currency_id,
              client_secret, provider_intent_id, idempotency_key, creation_time, modified_by)
-            VALUES (@Id, @OrderId, @Gw, @Status, @Amt, @Ccy, NULL, @ProvId, @Key, NOW(6), @ModBy);";
+            VALUES (@Id, @OrderId, @Gw, @Status, @Amt, @Ccy, NULL, @ProvId, @Key, SYSUTCDATETIME(), @ModBy);";
 
         internal const string Intent_UpdateProvideId = @"
                 UPDATE payment_intent
@@ -125,11 +124,11 @@ namespace GMS.TifoXRCoreWebAPI.Repositories.SQL
 
         internal const string Intent_Context = @"
             SELECT i.order_id, o.space_id, o.currency_id, o.total_net_amount, o.user_id, i.provider_intent_id, i.payment_gateway_id
-            FROM payment_intent i JOIN `order` o ON o.id=i.order_id
-            WHERE i.id=@IntentId LIMIT 1;";
+            FROM payment_intent i JOIN [order] o ON o.id=i.order_id
+            WHERE i.id=@IntentId;";
 
         internal const string Order_UpdateStatus = @"
-            UPDATE `order`
+            UPDATE [order]
             SET status_id=@StatusId,
                 change_reason=@ChangeReason,
                 modified_by=@ModBy
@@ -141,22 +140,22 @@ namespace GMS.TifoXRCoreWebAPI.Repositories.SQL
             JOIN payment_intent pi ON pi.id = pc.payment_intent_id
             WHERE pi.order_id=@OrderId;";
 
-        internal const string Order_GetTotalNet = @"SELECT total_net_amount FROM `order` WHERE id=@OrderId LIMIT 1;";
+        internal const string Order_GetTotalNet = @"SELECT TOP 1 total_net_amount FROM [order] WHERE id=@OrderId;";
 
         internal const string Order_UpdatePaidStatus = @"
-            UPDATE `order` SET status_id=@PaidStatusId, modified_by=@ModBy
+            UPDATE [order] SET status_id=@PaidStatusId, modified_by=@ModBy
             WHERE id=@OrderId AND status_id<>@PaidStatusId;";
 
         internal const string Order_GetHeader = @"
             SELECT space_id, currency_id, total_net_amount, gateway_preferred_id
-            FROM `order` WHERE id=@OrderId LIMIT 1;";
+            FROM [order] WHERE id=@OrderId;";
 
-        internal const string Currency_ResolveIso = @"SELECT ISO FROM currency WHERE id=@Id LIMIT 1;";
+        internal const string Currency_ResolveIso = @"SELECT TOP 1 ISO FROM currency WHERE id=@Id;";
 
-        internal const string Currency_SelectIsoById = @"SELECT ISO FROM currency WHERE id=@Id LIMIT 1;";
+        internal const string Currency_SelectIsoById = @"SELECT TOP 1 ISO FROM currency WHERE id=@Id;";
 
         // ----- Misc -----
-        internal const string Order_ExistsInSpace = @"SELECT 1 FROM `order` WHERE id=@OrderId AND space_id=@SpaceId;";
+        internal const string Order_ExistsInSpace = @"SELECT 1 FROM [order] WHERE id=@OrderId AND space_id=@SpaceId;";
     }
 }
 

--- a/Repositories/Sql/PaymentIntentSql.cs
+++ b/Repositories/Sql/PaymentIntentSql.cs
@@ -26,7 +26,7 @@ namespace GMS.TifoXRCoreWebAPI.Repositories.SQL
                   pi.provider_intent_id   AS ProviderIntentId,
                   ch.last_charge_id       AS LastChargeId,
                   o.total_net_amount      AS ExpectedPaidMinor
-                FROM `order` o
+                  FROM [order] o
                 LEFT JOIN (
                     SELECT order_id, MAX(creation_time) AS last_ct
                     FROM payment_intent GROUP BY order_id
@@ -47,7 +47,7 @@ namespace GMS.TifoXRCoreWebAPI.Repositories.SQL
                     JOIN payment_intent pi ON pi.id = pc.payment_intent_id
                     GROUP BY pi.order_id
                 ) ch ON ch.order_id = o.id
-                WHERE (pi.status_id IN (1,2)) OR (o.status_id = 3 AND (IFNULL(inv.cnt,0)=0 OR IFNULL(ent.cnt,0)=0));
+                  WHERE (pi.status_id IN (1,2)) OR (o.status_id = 3 AND (ISNULL(inv.cnt,0)=0 OR ISNULL(ent.cnt,0)=0));
             ";
 
         internal const string Order_Snapshot = @"
@@ -59,16 +59,14 @@ namespace GMS.TifoXRCoreWebAPI.Repositories.SQL
                             FROM order_adjustment oa WHERE oa.order_id=o.id),0) AS tax_major,
                   COALESCE((SELECT SUM(CASE WHEN (@FeeTypeId IS NOT NULL AND oa.item_type_id=@FeeTypeId) OR (@FeeTypeId IS NULL AND oa.code LIKE 'FEE_%') THEN oa.amount/@MinorDiv ELSE 0 END)
                             FROM order_adjustment oa WHERE oa.order_id=o.id),0) AS fee_major
-                FROM `order` o
-                WHERE o.id=@OrderId AND o.space_id=@SpaceId
-                LIMIT 1;";
+                  FROM [order] o
+                  WHERE o.id=@OrderId AND o.space_id=@SpaceId;";
 
         internal const string Charge_Snapshot = @"
                 SELECT pc.provider_charge_id, pi.payment_gateway_id
-                FROM payment_charge pc
-                JOIN payment_intent pi ON pi.id = pc.payment_intent_id
-                WHERE pc.id=@ChargeId
-                LIMIT 1;";
+                  FROM payment_charge pc
+                  JOIN payment_intent pi ON pi.id = pc.payment_intent_id
+                  WHERE pc.id=@ChargeId;";
 
         internal const string Invoice_Insert = @"
                 INSERT INTO invoice
@@ -79,30 +77,30 @@ namespace GMS.TifoXRCoreWebAPI.Repositories.SQL
                  bill_to_name, bill_to_email, notes, pdf_url, metadata,
                  creation_time, modified_by)
                 VALUES
-                (@Id, @No, @UserId, @OrderId, NULL,
-                 @Status, @ChargeId, @GatewayId, @ProvChargeId,
-                 @SpaceId, NOW(6), @CurrencyId,
-                 @Subtotal, @Discount, @Tax, @Fee, @Total,
-                 @BillToName, @BillToEmail, @Notes, NULL, @Metadata,
-                 NOW(6), @ModBy);";
+                  (@Id, @No, @UserId, @OrderId, NULL,
+                   @Status, @ChargeId, @GatewayId, @ProvChargeId,
+                   @SpaceId, SYSUTCDATETIME(), @CurrencyId,
+                   @Subtotal, @Discount, @Tax, @Fee, @Total,
+                   @BillToName, @BillToEmail, @Notes, NULL, @Metadata,
+                   SYSUTCDATETIME(), @ModBy);";
 
         internal const string Intent_FindLatestOrderWithPending = @"
             SELECT o.id
-            FROM `order` o
+              FROM [order] o
             JOIN order_line ol ON ol.order_id = o.id
             JOIN payment_intent pi ON pi.order_id = o.id AND pi.status_id IN (1,2) -- requires_action / processing
             WHERE o.space_id=@SpaceId AND o.user_id=@UserId
               AND ol.item_type_id=@ItemTypeId AND ol.item_ref_id=@ItemRefId
               AND (@GatewayId IS NULL OR pi.payment_gateway_id=@GatewayId)
-            ORDER BY pi.creation_time DESC
-            LIMIT 1;";
+              ORDER BY pi.creation_time DESC
+              OFFSET 0 ROWS FETCH NEXT 1 ROW ONLY;";
 
         internal const string Refund_Insert = @"
             INSERT INTO payment_refund
             (id, payment_charge_id, status_id, amount, currency_id, provider_refund_id, reason,
              refund_datetime, creation_time, modified_by)
-            VALUES (@Id, @ChargeId, @Status, @Amt, @Ccy, @ProvRefund, @Reason,
-                    NOW(6), NOW(6), @ModBy);";
+              VALUES (@Id, @ChargeId, @Status, @Amt, @Ccy, @ProvRefund, @Reason,
+                      SYSUTCDATETIME(), SYSUTCDATETIME(), @ModBy);";
 
         internal const string Charge_GetContext = @"
             SELECT
@@ -114,8 +112,8 @@ namespace GMS.TifoXRCoreWebAPI.Repositories.SQL
               pc.amount_captured                              AS amount_captured_minor,
               COALESCE(SUM(pr.amount), 0)                     AS total_refunded_so_far_minor
             FROM payment_charge pc
-            JOIN payment_intent pi ON pi.id = pc.payment_intent_id
-            JOIN `order` o        ON o.id  = pi.order_id
+              JOIN payment_intent pi ON pi.id = pc.payment_intent_id
+              JOIN [order] o        ON o.id  = pi.order_id
             LEFT JOIN payment_refund pr ON pr.payment_charge_id = pc.id
                                        AND pr.status_id = 2      -- succeeded only
             WHERE pc.id = @ChargeId
@@ -126,21 +124,22 @@ namespace GMS.TifoXRCoreWebAPI.Repositories.SQL
                 INSERT INTO entitlement
                     (id, order_line_id, user_id, status, quantity, granted_datetime,
                      revoked_reason, metadata, creation_time, modified_by)
-                SELECT UUID(), ol.id, o.user_id, @GrantedStatus, ol.quantity, NOW(6),
-                       NULL, ol.metadata, NOW(6), @ModBy
-                FROM order_line ol
-                JOIN `order` o ON o.id = ol.order_id
-                LEFT JOIN entitlement e ON e.order_line_id = ol.id
-                WHERE ol.order_id = @OrderId
-                  AND o.status_id = @OrderStatusPaid
+                  SELECT NEWID(), ol.id, o.user_id, @GrantedStatus, ol.quantity, SYSUTCDATETIME(),
+                         NULL, ol.metadata, SYSUTCDATETIME(), @ModBy
+                  FROM order_line ol
+                  JOIN [order] o ON o.id = ol.order_id
+                  LEFT JOIN entitlement e ON e.order_line_id = ol.id
+                  WHERE ol.order_id = @OrderId
+                    AND o.status_id = @OrderStatusPaid
                   AND e.id IS NULL;";
 
         internal const string Entitlement_RevokeByOrder = @"
-            UPDATE entitlement e
-            JOIN order_line ol ON ol.id = e.order_line_id
+            UPDATE e
             SET e.status = @RevokedStatus,
                 e.revoked_reason = @Reason,
                 e.modified_by = @ModBy
+            FROM entitlement e
+            JOIN order_line ol ON ol.id = e.order_line_id
             WHERE ol.order_id = @OrderId;";
     }
 }

--- a/Repositories/Sql/RewardSql.cs
+++ b/Repositories/Sql/RewardSql.cs
@@ -14,13 +14,13 @@ namespace GMS.TifoXRCoreWebAPI.Repositories.Sql
             INSERT INTO reward
             (reward_composition_type_id, name_key, description_key, space_id, entity_id, 
             max_total_claims, max_claims_per_user, cooldown_seconds,
-            claim_required, is_active, valid_from, valid_to, 
+            claim_required, is_active, valid_from, valid_to,
             creation_time, modified_by)
-            VALUES (@RewardCompositionTypeId, @NameKey, @DescriptionKey, @SpaceId, @EntityId, 
+            VALUES (@RewardCompositionTypeId, @NameKey, @DescriptionKey, @SpaceId, @EntityId,
             @MaxTotalClaims, @MaxClaimsPerUser, @CooldownSeconds,
-            @ClaimRequired, @IsActive, @ValidFrom, @ValidTo, 
-            NOW(6), 'system');
-            SELECT LAST_INSERT_ID();";
+            @ClaimRequired, @IsActive, @ValidFrom, @ValidTo,
+            SYSUTCDATETIME(), 'system');
+            SELECT CAST(SCOPE_IDENTITY() AS int);";
 
         public const string GetReward = @"
             SELECT
@@ -33,13 +33,13 @@ namespace GMS.TifoXRCoreWebAPI.Repositories.Sql
               max_total_claims AS MaxTotalClaims, 
               max_claims_per_user AS MaxClaimsPerUser,
               cooldown_seconds AS CooldownSeconds,
-              (claim_required + 0) AS ClaimRequired,
-              (is_active + 0) AS IsActive,
-              valid_from AS ValidFrom, 
+              CAST(claim_required AS int) AS ClaimRequired,
+              CAST(is_active AS int) AS IsActive,
+              valid_from AS ValidFrom,
               valid_to AS ValidTo
             FROM reward
             WHERE id=@Id AND space_id=@SpaceId
-            LIMIT 1;";
+            ;";
 
         public const string ListRewardsBySpace = @"
             SELECT
@@ -52,8 +52,8 @@ namespace GMS.TifoXRCoreWebAPI.Repositories.Sql
               max_total_claims    AS MaxTotalClaims,
               max_claims_per_user AS MaxClaimsPerUser,
               cooldown_seconds    AS CooldownSeconds,
-              (claim_required + 0) AS ClaimRequired,
-              (is_active + 0)      AS IsActive,
+              CAST(claim_required AS int) AS ClaimRequired,
+              CAST(is_active AS int)      AS IsActive,
               valid_from          AS ValidFrom,
               valid_to            AS ValidTo
             FROM reward
@@ -62,13 +62,13 @@ namespace GMS.TifoXRCoreWebAPI.Repositories.Sql
 
         public const string InsertRewardItem = @"
             INSERT INTO reward_items (reward_id, item_id, quantity, creation_time, modified_by)
-            VALUES (@RewardId, @ItemId, @Quantity, NOW(6), 'system');
-            SELECT LAST_INSERT_ID();";
+            VALUES (@RewardId, @ItemId, @Quantity, SYSUTCDATETIME(), 'system');
+            SELECT CAST(SCOPE_IDENTITY() AS int);";
 
         public const string InsertRewardCurrency = @"
             INSERT INTO reward_currency (reward_id, currency_id, amount, creation_time, modified_by)
-            VALUES (@RewardId, @CurrencyId, @Amount, NOW(6), 'system');
-            SELECT LAST_INSERT_ID();";
+            VALUES (@RewardId, @CurrencyId, @Amount, SYSUTCDATETIME(), 'system');
+            SELECT CAST(SCOPE_IDENTITY() AS int);";
 
         public const string ListRewardItems = @"
             SELECT id, item_id AS ItemId, quantity AS Quantity
@@ -113,18 +113,23 @@ namespace GMS.TifoXRCoreWebAPI.Repositories.Sql
             WHERE rar.reward_id = @RewardId;";
 
         // User rewards
-        public const string LookupPendingStatus = @"SELECT id FROM reward_status WHERE status = 'Pending' LIMIT 1;";
+        public const string LookupPendingStatus = @"SELECT TOP 1 id FROM reward_status WHERE status = 'Pending';";
 
         public const string InsertUserRewardIdempotent = @"
-            INSERT INTO user_reward
-            (user_id, reward_id, space_id, reward_status_id, 
-            grant_source, source_event_id, idempotency_key, 
-            claimed_at, expired_at, creation_time, modified_by)
-            VALUES (@UserId, @RewardId, @SpaceId, @PendingId, 
-            @GrantSource, @SourceEventId, @Idem, 
-            NOW(6), NULL, NOW(6), 'system')
-            ON DUPLICATE KEY UPDATE id = LAST_INSERT_ID(id);
-            SELECT LAST_INSERT_ID();";
+            MERGE user_reward AS target
+            USING (VALUES (@UserId, @RewardId, @SpaceId, @PendingId, @GrantSource, @SourceEventId, @Idem)) AS src
+                (user_id, reward_id, space_id, reward_status_id, grant_source, source_event_id, idempotency_key)
+            ON target.idempotency_key = src.idempotency_key
+            WHEN NOT MATCHED THEN
+                INSERT (user_id, reward_id, space_id, reward_status_id,
+                        grant_source, source_event_id, idempotency_key,
+                        claimed_at, expired_at, creation_time, modified_by)
+                VALUES (src.user_id, src.reward_id, src.space_id, src.reward_status_id,
+                        src.grant_source, src.source_event_id, src.idempotency_key,
+                        SYSUTCDATETIME(), NULL, SYSUTCDATETIME(), 'system')
+            WHEN MATCHED THEN
+                UPDATE SET id = target.id
+            OUTPUT inserted.id;";
 
         public const string GetUserRewardView = @"
             SELECT
@@ -145,21 +150,21 @@ namespace GMS.TifoXRCoreWebAPI.Repositories.Sql
 
         public const string SetDeliveredGuarded = @"
             UPDATE user_reward
-            SET reward_status_id = (SELECT id FROM reward_status WHERE status='Delivered' LIMIT 1),
+            SET reward_status_id = (SELECT TOP 1 id FROM reward_status WHERE status='Delivered'),
                 modified_by = 'system'
             WHERE id=@Id
-              AND reward_status_id = (SELECT id FROM reward_status WHERE status='Pending' LIMIT 1);";
+              AND reward_status_id = (SELECT TOP 1 id FROM reward_status WHERE status='Pending');";
 
         public const string SetClaimedGuarded = @"
             UPDATE user_reward
-            SET reward_status_id = (SELECT id FROM reward_status WHERE status='Claimed' LIMIT 1),
-                claimed_at = NOW(6),
+            SET reward_status_id = (SELECT TOP 1 id FROM reward_status WHERE status='Claimed'),
+                claimed_at = SYSUTCDATETIME(),
                 modified_by = 'system'
             WHERE id=@Id
                 AND reward_status_id IN (
                     SELECT id FROM reward_status WHERE status IN ('Pending','Delivered'));";
 
         public const string ExistsUserReward = @"
-            SELECT 1 FROM user_reward WHERE id = @Id LIMIT 1;";
+            SELECT TOP 1 1 FROM user_reward WHERE id = @Id;";
     }
 }

--- a/Repositories/Sql/RulesMetadataSql.cs
+++ b/Repositories/Sql/RulesMetadataSql.cs
@@ -16,8 +16,8 @@ namespace GMS.TifoXRCoreWebAPI.Repositories.Sql
 
         public const string InsertEventType = @"
             INSERT INTO re_event_type (name, creation_time, modified_by)
-            VALUES (@Name, NOW(6), 'system');
-            SELECT LAST_INSERT_ID();";
+            VALUES (@Name, SYSUTCDATETIME(), 'system');
+            SELECT CAST(SCOPE_IDENTITY() AS int);";
 
         public const string UpdateEventType = @"
             UPDATE re_event_type
@@ -27,7 +27,7 @@ namespace GMS.TifoXRCoreWebAPI.Repositories.Sql
 
         public const string SelectContextParameters = @"
             SELECT cp.id AS Id,
-                   cp.`key` AS `Key`,
+                   cp.[key] AS [Key],
                    cp.source AS Source,
                    cp.path AS Path,
                    cp.re_path_type_id AS RePathTypeId,
@@ -47,18 +47,18 @@ namespace GMS.TifoXRCoreWebAPI.Repositories.Sql
 
         public const string InsertContextParameter = @"
             INSERT INTO re_context_parameter
-                (`key`, source, path, re_path_type_id, data_type,
+                ([key], source, path, re_path_type_id, data_type,
                  ui_label, ui_help_key, unit, re_dropdown_value_provider_id,
                  example_value, creation_time, modified_by)
             VALUES
                 (@Key, @Source, @Path, @RePathTypeId, @DataType,
                  @UiLabel, @UiHelpKey, @Unit, @DropdownProviderId,
-                 @ExampleValue, NOW(6), 'system');
-            SELECT LAST_INSERT_ID();";
+                 @ExampleValue, SYSUTCDATETIME(), 'system');
+            SELECT CAST(SCOPE_IDENTITY() AS int);";
 
         public const string UpdateContextParameter = @"
             UPDATE re_context_parameter
-            SET `key` = @Key,
+            SET [key] = @Key,
                 source = @Source,
                 path = @Path,
                 re_path_type_id = @RePathTypeId,
@@ -75,8 +75,8 @@ namespace GMS.TifoXRCoreWebAPI.Repositories.Sql
             SELECT etp.id AS Id,
                    etp.re_event_type_id AS EventTypeId,
                    etp.parameter_id AS ParameterId,
-                   cp.`key` AS ParameterKey,
-                   (etp.is_required + 0) AS IsRequired,
+                   cp.[key] AS ParameterKey,
+                   CAST(etp.is_required AS int) AS IsRequired,
                    etp.default_value_json AS DefaultValueJson
             FROM re_event_type_parameter etp
             JOIN re_context_parameter cp ON cp.id = etp.parameter_id
@@ -86,8 +86,8 @@ namespace GMS.TifoXRCoreWebAPI.Repositories.Sql
         public const string InsertEventTypeParameter = @"
             INSERT INTO re_event_type_parameter
                 (re_event_type_id, parameter_id, is_required, default_value_json, creation_time, modified_by)
-            VALUES (@EventTypeId, @ParameterId, @IsRequired, @DefaultValueJson, NOW(6), 'system');
-            SELECT LAST_INSERT_ID();";
+            VALUES (@EventTypeId, @ParameterId, @IsRequired, @DefaultValueJson, SYSUTCDATETIME(), 'system');
+            SELECT CAST(SCOPE_IDENTITY() AS int);";
 
         public const string UpdateEventTypeParameter = @"
             UPDATE re_event_type_parameter

--- a/Repositories/Sql/RulesSql.cs
+++ b/Repositories/Sql/RulesSql.cs
@@ -10,46 +10,42 @@ namespace GMS.TifoXRCoreWebAPI.Repositories.Sql
     public static class RulesSql
     {
         public const string GetWorkflowSpace = @"
-            SELECT space_id FROM workflow WHERE id = @Id LIMIT 1;";
+            SELECT TOP 1 space_id FROM workflow WHERE id = @Id;";
 
         public const string GetRuleContext = @"
-            SELECT id, space_id AS SpaceId, workflow_id AS WorkflowId
+            SELECT TOP 1 id, space_id AS SpaceId, workflow_id AS WorkflowId
             FROM rules
-            WHERE id = @Id
-            LIMIT 1;";
+            WHERE id = @Id;";
 
         public const string ConditionGroupBelongsToRule = @"
-            SELECT 1 FROM rule_condition_group WHERE id = @GroupId AND rule_id = @RuleId LIMIT 1;";
+            SELECT TOP 1 1 FROM rule_condition_group WHERE id = @GroupId AND rule_id = @RuleId;";
 
         public const string ActionBelongsToRule = @"
-            SELECT 1 FROM rule_actions WHERE id = @ActionId AND rule_id = @RuleId LIMIT 1;";
+            SELECT TOP 1 1 FROM rule_actions WHERE id = @ActionId AND rule_id = @RuleId;";
 
         public const string GetActionContext = @"
-            SELECT ra.rule_id AS RuleId, r.space_id AS SpaceId
+            SELECT TOP 1 ra.rule_id AS RuleId, r.space_id AS SpaceId
             FROM rule_actions ra
             JOIN rules r ON r.id = ra.rule_id
-            WHERE ra.id = @Id
-            LIMIT 1;";
+            WHERE ra.id = @Id;";
 
         public const string GetConditionGroupContext = @"
-            SELECT rcg.rule_id AS RuleId, r.space_id AS SpaceId
+            SELECT TOP 1 rcg.rule_id AS RuleId, r.space_id AS SpaceId
             FROM rule_condition_group rcg
             JOIN rules r ON r.id = rcg.rule_id
-            WHERE rcg.id = @Id
-            LIMIT 1;";
+            WHERE rcg.id = @Id;";
 
         public const string GetConditionContext = @"
-            SELECT rc.group_id AS GroupId,
+            SELECT TOP 1 rc.group_id AS GroupId,
                    rcg.rule_id AS RuleId,
                    r.space_id AS SpaceId
             FROM rule_condition rc
             JOIN rule_condition_group rcg ON rcg.id = rc.group_id
             JOIN rules r ON r.id = rcg.rule_id
-            WHERE rc.id = @Id
-            LIMIT 1;";
+            WHERE rc.id = @Id;";
 
         public const string GetStateTypeIdByName = @"
-            SELECT id FROM state_type WHERE type = @Type LIMIT 1;";
+            SELECT TOP 1 id FROM state_type WHERE type = @Type;";
 
         public const string GetRuleDetail = @"
             SELECT r.id AS RuleId,
@@ -69,8 +65,7 @@ namespace GMS.TifoXRCoreWebAPI.Repositories.Sql
             FROM rules r
             JOIN workflow w ON w.id = r.workflow_id
             LEFT JOIN re_event_type et ON et.name = r.target_type
-            WHERE r.id = @RuleId
-            LIMIT 1;";
+            WHERE r.id = @RuleId;";
 
         public const string GetRuleConditionGroups = @"
             SELECT g.id AS Id,
@@ -93,13 +88,13 @@ namespace GMS.TifoXRCoreWebAPI.Repositories.Sql
                    rc.group_id AS GroupId,
                    rc.parameter_id AS ParameterId,
                    rc.comparator_id AS ComparatorId,
-                   (rc.negate + 0) AS Negate,
+                   CAST(rc.negate AS int) AS Negate,
                    rc.right_value_kind AS RightValueKind,
                    rc.right_value_json AS RightValueJson,
                    rc.order_index AS OrderIndex,
                    cmp.code AS ComparatorCode,
                    cmp.engine_format AS ComparatorFormat,
-                   cp.`key` AS ParameterKey,
+                   cp.[key] AS ParameterKey,
                    cp.source AS ParameterSource,
                    cp.path AS ParameterPath
             FROM rule_condition rc
@@ -119,14 +114,14 @@ namespace GMS.TifoXRCoreWebAPI.Repositories.Sql
                 priority = @Priority,
                 rule_cooldown_seconds = @RuleCooldownSeconds,
                 expression = @Expression,
-                modified_time = NOW(6),
+                modified_time = SYSUTCDATETIME(),
                 modified_by = 'system'
             WHERE id = @RuleId;";
 
         public const string InsertWorkflow = @"
             INSERT INTO workflow (space_id, name, state_type_id, creation_time, modified_by)
-            VALUES (@SpaceId, @Name, @StateTypeId, NOW(6), 'system');
-            SELECT LAST_INSERT_ID();";
+            VALUES (@SpaceId, @Name, @StateTypeId, SYSUTCDATETIME(), 'system');
+            SELECT CAST(SCOPE_IDENTITY() AS int);";
 
         public const string InsertRule = @"
             INSERT INTO rules (workflow_id, space_id, rule_name, expression, target_type,
@@ -136,25 +131,25 @@ namespace GMS.TifoXRCoreWebAPI.Repositories.Sql
             VALUES (@WorkflowId, @SpaceId, @RuleName, @Expression, @TargetType,
                     @Version, @ParentRuleId, @SuccessEvent,
                     @Priority, @Cooldown, @StateTypeId,
-                    NOW(6), 'system');
-            SELECT LAST_INSERT_ID();";
+                    SYSUTCDATETIME(), 'system');
+            SELECT CAST(SCOPE_IDENTITY() AS int);";
 
         public const string InsertConditionGroup = @"
             INSERT INTO rule_condition_group (rule_id, parent_group_id, re_logical_operator_id, order_index, creation_time, modified_by)
-            VALUES (@RuleId, @ParentGroupId, @LogicalOperatorId, @OrderIndex, NOW(6), 'system');
-            SELECT LAST_INSERT_ID();";
+            VALUES (@RuleId, @ParentGroupId, @LogicalOperatorId, @OrderIndex, SYSUTCDATETIME(), 'system');
+            SELECT CAST(SCOPE_IDENTITY() AS int);";
 
         public const string InsertCondition = @"
             INSERT INTO rule_condition (group_id, parameter_id, comparator_id, negate, right_value_kind, right_value_json, order_index, creation_time, modified_by)
-            VALUES (@GroupId, @ParameterId, @ComparatorId, @Negate, @RightValueKind, @RightValueJson, @OrderIndex, NOW(6), 'system');
-            SELECT LAST_INSERT_ID();";
+            VALUES (@GroupId, @ParameterId, @ComparatorId, @Negate, @RightValueKind, @RightValueJson, @OrderIndex, SYSUTCDATETIME(), 'system');
+            SELECT CAST(SCOPE_IDENTITY() AS int);";
 
         public const string UpdateConditionGroup = @"
             UPDATE rule_condition_group
             SET parent_group_id = @ParentGroupId,
                 re_logical_operator_id = @LogicalOperatorId,
                 order_index = @OrderIndex,
-                modified_time = NOW(6),
+                modified_time = SYSUTCDATETIME(),
                 modified_by = 'system'
             WHERE id = @Id;";
 
@@ -167,26 +162,32 @@ namespace GMS.TifoXRCoreWebAPI.Repositories.Sql
                 right_value_kind = @RightValueKind,
                 right_value_json = @RightValueJson,
                 order_index = @OrderIndex,
-                modified_time = NOW(6),
+                modified_time = SYSUTCDATETIME(),
                 modified_by = 'system'
             WHERE id = @Id;";
 
         public const string UpdateRuleExpression = @"
             UPDATE rules
             SET expression = @Expression,
-                modified_time = NOW(6),
+                modified_time = SYSUTCDATETIME(),
                 modified_by = 'system'
             WHERE id = @RuleId;";
 
         public const string InsertRuleAction = @"
             INSERT INTO rule_actions (rule_id, action_type_id, action_name, action_key, action_parameters_json, action_target_ref, order_index, is_active, creation_time, modified_by)
-            VALUES (@RuleId, @ActionTypeId, @ActionName, @ActionKey, @ActionParams, @ActionTargetRef, @OrderIndex, @IsActive, NOW(6), 'system');
-            SELECT LAST_INSERT_ID();";
+            VALUES (@RuleId, @ActionTypeId, @ActionName, @ActionKey, @ActionParams, @ActionTargetRef, @OrderIndex, @IsActive, SYSUTCDATETIME(), 'system');
+            SELECT CAST(SCOPE_IDENTITY() AS int);";
 
         public const string UpsertRuleActionReward = @"
-            INSERT INTO rule_action_reward (id, reward_id, creation_time, modified_by)
-            VALUES (@ActionId, @RewardId, NOW(6), 'system')
-            ON DUPLICATE KEY UPDATE reward_id = VALUES(reward_id), modified_by = 'system';";
+            MERGE rule_action_reward AS target
+            USING (VALUES (@ActionId, @RewardId)) AS src (id, reward_id)
+            ON target.id = src.id
+            WHEN MATCHED THEN
+                UPDATE SET reward_id = src.reward_id,
+                           modified_by = 'system'
+            WHEN NOT MATCHED THEN
+                INSERT (id, reward_id, creation_time, modified_by)
+                VALUES (src.id, src.reward_id, SYSUTCDATETIME(), 'system');";
 
         public const string GetRuntimeWorkflows = @"
             SELECT w.id AS WorkflowId,
@@ -205,10 +206,10 @@ namespace GMS.TifoXRCoreWebAPI.Repositories.Sql
 
         public const string GetRuntimeEventParameters = @"
             SELECT etp.re_event_type_id AS EventTypeId,
-                   cp.`key` AS ParameterKey,
+                   cp.[key] AS ParameterKey,
                    cp.source AS Source,
                    cp.path AS Path,
-                   (etp.is_required + 0) AS IsRequired,
+                   CAST(etp.is_required AS int) AS IsRequired,
                    etp.default_value_json AS DefaultValueJson
             FROM re_event_type_parameter etp
             JOIN re_context_parameter cp ON cp.id = etp.parameter_id

--- a/Repositories/TeleportTableRepository.cs
+++ b/Repositories/TeleportTableRepository.cs
@@ -50,10 +50,10 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
                     bi.value AS button_localized_value
                 
                 FROM teleport_table t
-                LEFT JOIN i18n i ON i.`key` = t.name_key AND i.space_id = t.space_id
+                LEFT JOIN i18n i ON i.[key] = t.name_key AND i.space_id = t.space_id
                 LEFT JOIN teleport_table_button b ON b.table_id = t.id
                 LEFT JOIN map_spot ms ON ms.id = b.map_spot_id
-                LEFT JOIN i18n bi ON bi.`key` = b.name_key AND bi.space_id = t.space_id
+                LEFT JOIN i18n bi ON bi.[key] = b.name_key AND bi.space_id = t.space_id
                 WHERE t.space_id = @SpaceId
                 ORDER BY b.id, bi.locale_id;
             ";
@@ -213,7 +213,7 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
 
                 // Retrieve the new table id (MySQL)
                 int tableId;
-                const string getLastIdSql = "SELECT LAST_INSERT_ID();";
+                const string getLastIdSql = "SELECT CAST(SCOPE_IDENTITY() AS int);";
                 await using (var idCmd = _db.CreateCommand(conn, getLastIdSql))
                 {
                     idCmd.Transaction = tx;
@@ -225,7 +225,7 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
                 if (dto.LocalizedPairs?.Values != null && !string.IsNullOrWhiteSpace(dto.LocalizedPairs.Key))
                 {
                     const string insI18n = @"
-                INSERT INTO i18n (`key`, locale_id, value, space_id)
+                INSERT INTO i18n ([key], locale_id, value, space_id)
                 VALUES (@Key, @LocaleId, @Value, @SpaceId);";
 
                     foreach (var loc in dto.LocalizedPairs.Values)
@@ -358,12 +358,12 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
                 const string updI18n = @"
             UPDATE i18n
                SET value = @Value
-             WHERE `key`     = @NameKey
+             WHERE [key]     = @NameKey
                AND locale_id = @LocaleId
                AND space_id  = @SpaceId;";
 
                 const string insI18n = @"
-            INSERT INTO i18n (`key`, locale_id, value, space_id)
+            INSERT INTO i18n ([key], locale_id, value, space_id)
             VALUES (@NameKey, @LocaleId, @Value, @SpaceId);";
 
                 if (dto.LocalizedPairs?.Values != null)
@@ -441,7 +441,7 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
                             await cmdI.ExecuteNonQueryAsync();
 
                             // get new id
-                            await using var idCmd = _db.CreateCommand(conn, "SELECT LAST_INSERT_ID();");
+                            await using var idCmd = _db.CreateCommand(conn, "SELECT CAST(SCOPE_IDENTITY() AS int);");
                             idCmd.Transaction = tx;
                             btnId = Convert.ToInt32(await idCmd.ExecuteScalarAsync());
                         }
@@ -566,7 +566,7 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
                         paramNames.Add($"@BtnKey{i}");
 
                     var delBtnI18nSql =
-                        $"DELETE FROM i18n WHERE `key` IN ({string.Join(",", paramNames)}) AND space_id = @SpaceId;";
+                        $"DELETE FROM i18n WHERE [key] IN ({string.Join(",", paramNames)}) AND space_id = @SpaceId;";
 
                     await using var delBtnI18nCmd = _db.CreateCommand(conn, delBtnI18nSql);
                     delBtnI18nCmd.Transaction = tx;
@@ -584,7 +584,7 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
                 {
                     const string delTableI18n = @"
                 DELETE FROM i18n 
-                 WHERE `key` = @NameKey AND space_id = @SpaceId;";
+                 WHERE [key] = @NameKey AND space_id = @SpaceId;";
 
                     await using var delTableI18nCmd = _db.CreateCommand(conn, delTableI18n);
                     delTableI18nCmd.Transaction = tx;
@@ -700,7 +700,7 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
                 // 2) Delete i18n for this button (no space filter to match original behavior)
                 if (!string.IsNullOrWhiteSpace(btnKey))
                 {
-                    const string delBtnI18nSql = @"DELETE FROM i18n WHERE `key` = @BtnKey;";
+                    const string delBtnI18nSql = @"DELETE FROM i18n WHERE [key] = @BtnKey;";
                     await using var delBtnI18nCmd = _db.CreateCommand(conn, delBtnI18nSql);
                     delBtnI18nCmd.Transaction = tx;
                     delBtnI18nCmd.Parameters.Add(_db.CreateParameter("@BtnKey", btnKey!));
@@ -768,10 +768,10 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
             bi.locale_id AS button_locale_id,
             bi.value AS button_localized_value
         FROM teleport_table t
-        LEFT JOIN i18n i  ON i.`key` = t.name_key AND i.space_id = t.space_id
+        LEFT JOIN i18n i  ON i.[key] = t.name_key AND i.space_id = t.space_id
         LEFT JOIN teleport_table_button b ON b.table_id = t.id
         LEFT JOIN map_spot ms ON ms.id = b.map_spot_id
-        LEFT JOIN i18n bi ON bi.`key` = b.name_key AND bi.space_id = t.space_id
+        LEFT JOIN i18n bi ON bi.[key] = b.name_key AND bi.space_id = t.space_id
         WHERE t.space_id = @SpaceId AND t.id = @TableId
         ORDER BY b.id, bi.locale_id;";
 
@@ -941,7 +941,7 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
                         }
 
                         // fetch new id
-                        const string getLastIdSql = "SELECT LAST_INSERT_ID();";
+                        const string getLastIdSql = "SELECT CAST(SCOPE_IDENTITY() AS int);";
                         await using (var idCmd = _db.CreateCommand(connection, getLastIdSql))
                         {
                             idCmd.Transaction = tx;
@@ -1008,7 +1008,7 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
                 }
 
                 // fetch new button id
-                const string getButtonIdSql = "SELECT LAST_INSERT_ID();";
+                const string getButtonIdSql = "SELECT CAST(SCOPE_IDENTITY() AS int);";
                 await using (var idBtn = _db.CreateCommand(connection, getButtonIdSql))
                 {
                     idBtn.Transaction = tx;
@@ -1021,7 +1021,7 @@ namespace GMS.TifoXRCoreWebAPI.Repositories
                     !string.IsNullOrWhiteSpace(btnDto.LocalizedPairs.Key))
                 {
                     const string insI18n = @"
-                INSERT INTO i18n (`key`, locale_id, value, space_id)
+                INSERT INTO i18n ([key], locale_id, value, space_id)
                 VALUES (@Key, @LocaleId, @Value, @SpaceId);";
 
                     foreach (var loc in btnDto.LocalizedPairs.Values)


### PR DESCRIPTION
## Summary
- replace MySQL-specific syntax and quoting with SQL Server-compatible statements across repositories and SQL helpers
- switch timestamp and identity retrieval functions to SQL Server equivalents and update idempotent merge logic
- adjust UUID and boolean handling to SQL Server-supported expressions

## Testing
- Not run (dotnet CLI not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6941ba45f1a4832988621e9f4a558aa6)